### PR TITLE
Correct componets to components

### DIFF
--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -24,7 +24,7 @@ function globAsync(pattern) {
  *
  * Example:
  *
- *   compileAll({ base: './componets', match: 'ma/*' })
+ *   compileAll({ base: './components', match: 'ma/*' })
  *   compileAll({ base: './node_modules', match: '{semver,heredoc}', dest: './public' })
  *
  * Return value:


### PR DESCRIPTION
读源码的时候，照着注释里面的 `compileAll({ base: './componets', match: 'ma/*' })` 拷出来，贴到本地仓库，结果没编译出结果，对比下，发现 componets 的单词误拼写了