### PR TITLE
Support multiple bases

### DIFF
--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -369,9 +369,9 @@ function* compileAll(opts) {
   var dest = path.resolve(root, opts.dest || 'public')
   var match = opts.match || '**/main.js'
   var sourceOptions = opts.sourceOptions
-  var bases = [].concat(opts.base || 'components')
-
-  bases = bases.map(base => path.resolve(root, base))
+  var bases = [].concat(opts.base || 'components').map(function(base) {
+    return path.resolve(root, base)
+  })
 
   var dependenciesMap = yield* parseMap({ root: root, base: bases, dest: dest })
   var compiled = {}
@@ -461,7 +461,9 @@ function* compileComponent(id, opts) {
   }, opts)
 
   var root = opts.root
-  var bases = [].concat(opts.base).map(base => path.resolve(root, base))
+  var bases = [].concat(opts.base).map(function(base) {
+    return path.resolve(root, base)
+  })
   var dependenciesMap = opts.dependenciesMap
   var includeModules = opts.includeModules
 

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -5,6 +5,7 @@
  */
 var path = require('path')
 var glob = require('glob')
+var util = require('util')
 var debug = require('debug')('oceanify')
 var mkdirp = require('mkdirp')
 var fs = require('fs')
@@ -131,6 +132,23 @@ function findModule(route, dependenciesMap, requiredMap) {
 
 
 /**
+ * Find the path of a component in mutiple base directories
+ *
+ * @param {string} id
+ * @param {Array}  bases
+ * @yield {string} path of the component found
+ */
+function* findComponent(id, bases) {
+  for (let i = 0; i < bases.length; i++) {
+    let componentPath = path.join(bases[i], id)
+    if (yield exists(componentPath)) {
+      return componentPath
+    }
+  }
+}
+
+
+/**
  * Bundle a component or module, with its relative dependencies included by
  * default. And if passed opts.dependenciesMap, include all the dependencies.
  *
@@ -139,7 +157,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  *
  *     _bundle('main', {
  *       root: root,
- *       base: path.join(root, 'components'),
+ *       bases: path.join(root, 'components'),
  *       dependenciesMap: dependenciesMap,
  *       toplevel: yield* parseLoader(dependenciesMap)
  *     })
@@ -148,7 +166,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  *     // `./lib/foo` can be appended directly but `ez-editor` needs _bundle
  *     _bundle('ez-editor/0.2.4/index', {
  *       root: root,
- *       base: path.join(root, 'node_modules'),
+ *       bases: path.join(root, 'node_modules'),
  *       dependenciesMap: dependenciesMap,
  *       toplevel: toplevel,   // current toplevel ast,
  *       ids: ['main', 'lib/foo'],
@@ -158,7 +176,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  *     // found out that the dependencies of ez-editor are ['yen'] and so on.
  *     _bundle('yen/1.2.4/index', {
  *       root: path.join(root, 'node_modules/ez-editor'),
- *       base: path.join(root, 'node_modules/ez-editor/node_modules'),
+ *       bases: path.join(root, 'node_modules/ez-editor/node_modules'),
  *       dependenciesMap: dependenciesMap,
  *       toplevel: toplevel,
  *       ids: ['main', 'lib/foo', 'ez-editor/0.2.4/index'],
@@ -168,7 +186,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  * @param {string}   main
  * @param {Object}   opts
  * @param {string}   opts.root                  the source root
- * @param {string}   opts.base                  the base of current module
+ * @param {string}   opts.bases                 the bases of current module
  * @param {object}  [opts.dependenciesMap=null]
  * @param {object}  [opts.requiredMap=null]
  * @param {boolean} [opts.includeModules]       include dependencies in node_modules
@@ -181,7 +199,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  */
 function* _bundle(main, opts) {
   var root = opts.root
-  var base = opts.base
+  var bases = [].concat(opts.bases)
   var toplevel = opts.toplevel
   var dependenciesMap = opts.dependenciesMap
   var requiredMap = opts.requiredMap
@@ -194,7 +212,12 @@ function* _bundle(main, opts) {
     if (ids.indexOf(id) >= 0) return
     ids.unshift(id)
 
-    var fpath = path.join(base, stripVersion(id)) + '.js'
+    var sourceId = stripVersion(id)
+    var fpath = yield findComponent(sourceId + '.js', bases)
+
+    if (!fpath && !factory) {
+      throw new Error(util.format('Cannot find source of %s in %s', id, bases))
+    }
 
     factory = factory || (yield readFile(fpath, 'utf-8'))
     dependencies = dependencies || matchRequire.findAll(factory)
@@ -205,6 +228,7 @@ function* _bundle(main, opts) {
       }
     }
 
+    fpath = fpath || path.join(bases[0], sourceId + '.js')
     toplevel = UglifyJS.parse(define(id, dependencies, factory), {
       filename: path.relative(root, fpath),
       toplevel: toplevel
@@ -220,7 +244,7 @@ function* _bundle(main, opts) {
       if (dep.charAt(0) === '.') {
         yield* append(path.join(path.dirname(component.id), dep))
       }
-      else if (yield exists(path.join(base, dep + '.js'))) {
+      else if (yield findComponent(dep + '.js', bases)) {
         yield* append(dep)
       }
       else if (dependenciesMap && includeModules) {
@@ -240,7 +264,7 @@ function* _bundle(main, opts) {
 
     yield* _bundle(id, {
       root: root,
-      base: pkgBase,
+      bases: pkgBase,
       dependenciesMap: dependenciesMap,
       requiredMap: requiredMap,
       includeModules: includeModules,
@@ -257,13 +281,6 @@ function* _bundle(main, opts) {
 
 
 /**
- * Process ast into compiled js and source map
- *
- * @param    {string}  id
- * @param    {uAST}    ast
- * @param    {Object}  sourceOpts          Source map options
- * @param    {string} [sourceOpts.root=''] Source root
- *
  * @typedef  {ProcessResult}
  * @type     {Object}
  * @property {string} js  Compiled javascript
@@ -271,11 +288,20 @@ function* _bundle(main, opts) {
  *
  * @returns  {ProcessResult}
  */
-function _process(id, ast, sourceOpts) {
+
+/**
+ * Process ast into compiled js and source map
+ *
+ * @param    {string}  id
+ * @param    {uAST}    ast
+ * @param    {Object}  sourceOptions          Source map options
+ * @param    {string} [sourceOptions.root=''] Source root
+ */
+function _process(id, ast, sourceOptions) {
   /* eslint-disable camelcase */
-  sourceOpts = objectAssign({
+  sourceOptions = objectAssign({
     root: ''
-  }, sourceOpts || {})
+  }, sourceOptions || {})
   var compressor = new UglifyJS.Compressor()
 
   deheredoc(ast)
@@ -289,7 +315,7 @@ function _process(id, ast, sourceOpts) {
 
   var sourceMap = new UglifyJS.SourceMap({
     file: id + '.js',
-    root: sourceOpts.root
+    root: sourceOptions.root
   })
   var stream = new UglifyJS.OutputStream({
     ascii_only: true,
@@ -316,7 +342,7 @@ function* _compileFile(id, opts) {
 
   yield mkdirpAsync(path.dirname(assetPath))
   yield [
-    writeFile(assetPath, opts.js + '\n//# sourceMappingURL=./' + id + '.js.map'),
+    writeFile(assetPath, opts.js + '\n//# sourceMappingURL=./' + path.basename(id) + '.js.map'),
     writeFile(assetPath + '.map', opts.map)
   ]
 
@@ -331,20 +357,23 @@ function* _compileFile(id, opts) {
  *
  *   compileAll({ base: './components', match: 'main/*' })
  *
- * @param {Object}  opts
- * @param {string} [opts.base=components]          The base directory to find the sources
- * @param {string} [opts.dest=public]              The destintation directory
- * @param {string} [opts.match={main,main\/**\/*}] The match pattern to find the components to compile
- * @param {string} [opts.root=process.cwd()]       Current working directory
+ * @param {Object}        opts
+ * @param {string|Array} [opts.base=components]          The base directory to find the sources
+ * @param {string}       [opts.dest=public]              The destintation directory
+ * @param {string}       [opts.match={main,main\/**\/*}] The match pattern to find the components to compile
+ * @param {string}       [opts.root=process.cwd()]       Current working directory
  */
 function* compileAll(opts) {
   opts = opts || {}
   var root = opts.root || process.cwd()
-  var base = path.resolve(root, opts.base || 'components')
   var dest = path.resolve(root, opts.dest || 'public')
-  var match = opts.match || '{main,main/**/*}.js'
+  var match = opts.match || '**/main.js'
+  var sourceOptions = opts.sourceOptions
+  var bases = [].concat(opts.base || 'components')
 
-  var dependenciesMap = yield* parseMap({ root: root, base: base, dest: dest })
+  bases = bases.map(base => path.resolve(root, base))
+
+  var dependenciesMap = yield* parseMap({ root: root, base: bases, dest: dest })
   var compiled = {}
 
   function* walk(deps) {
@@ -358,7 +387,8 @@ function* compileAll(opts) {
       yield* compileModule(path.join(name, mod.version, main), {
         root: root,
         base: path.resolve(mod.dir, '..'),
-        dest: dest
+        dest: dest,
+        sourceOptions: sourceOptions
       })
 
       yield* walk(mod.dependencies)
@@ -366,23 +396,27 @@ function* compileAll(opts) {
   }
 
   yield* walk(dependenciesMap)
-  var entries = yield globAsync(path.join(base, match))
 
-  if (!entries.length) {
-    console.error('Found no entries that macth %s in %s', opts.match, base)
-    return
-  }
+  for (let i = 0; i < bases.length; i++) {
+    let base = bases[i]
+    let entries = yield globAsync(path.join(base, match))
 
-  for (var i = 0, len = entries.length; i < len; i++) {
-    let id = path.relative(base, entries[i]).replace(/\.js$/, '')
+    if (!entries.length) {
+      console.error('Found no entries that macth %s in %s', match, base)
+    }
 
-    yield* compileComponent(id, {
-      root: root,
-      base: base,
-      dest: dest,
-      dependenciesMap: dependenciesMap,
-      includeModules: false
-    })
+    for (let j = 0, len = entries.length; j < len; j++) {
+      let id = path.relative(base, entries[j]).replace(/\.js$/, '')
+
+      yield* compileComponent(id, {
+        root: root,
+        base: bases,
+        dest: dest,
+        dependenciesMap: dependenciesMap,
+        includeModules: false,
+        sourceOptions: sourceOptions
+      })
+    }
   }
 }
 
@@ -411,7 +445,7 @@ function* parseLoader() {
  * @param {Object}          opts
  * @param {DependenciesMap} opts.dependenciesMap
  * @param {string}         [opts.dest]
- * @param {string}         [opts.base=components]
+ * @param {string|Array}   [opts.base=components]
  * @param {boolean}        [opts.includeModules]       Whethor to include node_modules or not
  * @param {Array}          [opts.dependencies]         Dependencies of the entry module
  * @param {string}         [opts.factory]              Factory code of the entry module
@@ -427,7 +461,7 @@ function* compileComponent(id, opts) {
   }, opts)
 
   var root = opts.root
-  var base = path.resolve(root, opts.base)
+  var bases = [].concat(opts.base).map(base => path.resolve(root, base))
   var dependenciesMap = opts.dependenciesMap
   var includeModules = opts.includeModules
 
@@ -435,7 +469,7 @@ function* compileComponent(id, opts) {
   var toplevel = yield* parseLoader()
   var bundleOpts = {
     root: root,
-    base: base,
+    bases: bases,
     dependencies: opts.dependencies,
     factory: opts.factory,
     includeModules: includeModules,
@@ -486,13 +520,13 @@ function* compileModule(id, opts) {
 
   var toplevel = yield* _bundle(id, {
     root: root,
-    base: base,
+    bases: base,
     dependenciesMap: opts.dependenciesMap,
     includeModules: !!opts.dependenciesMap
   })
 
   var dest = opts.dest && path.resolve(root, opts.dest)
-  var result = _process(id, toplevel)
+  var result = _process(id, toplevel, opts.sourceOptions)
 
   if (dest) {
     yield* _compileFile(id, {

--- a/lib/parseMap.js
+++ b/lib/parseMap.js
@@ -105,6 +105,29 @@ function* resolveModule(opts) {
 }
 
 
+/**
+ * Find the path of a component in mutiple base directories
+ *
+ * @param {string} id
+ * @param {Array}  bases
+ * @yield {string} path of the component found
+ */
+function* findComponent(id, bases) {
+  for (let i = 0; i < bases.length; i++) {
+    let componentPath = path.join(bases[i], id)
+    if (yield exists(componentPath)) {
+      return componentPath
+    }
+  }
+}
+
+
+/**
+ * Warn about unmet dependency
+ *
+ * @param  {string} name      name of the dependency
+ * @param  {string} dependent name of the dependent
+ */
 function unmetDependency(name, dependent) {
   console.warn(format('Unmet dependency %s required by %s',
     name, dependent)
@@ -148,9 +171,13 @@ function unmetDependency(name, dependent) {
 function* parseMap(opts) {
   opts = opts || {}
   var root = opts.root || process.cwd()
-  var base = path.resolve(root, opts.base || 'components')
   var encoding = opts.encoding || 'utf-8'
   var pkg = require(path.relative(__dirname, path.join(root, 'package.json')))
+  var bases = [].concat(opts.base || 'components').map(function(dir) {
+    return path.resolve(root, dir)
+  })
+  var base
+  var dependencies = {}
 
   function* parseComponent(fpath) {
     var code = yield readFile(fpath, encoding)
@@ -170,7 +197,7 @@ function* parseMap(opts) {
       if (name.charAt(0) === '.' || name in result) continue
 
       // exists in components dir.
-      if (yield exists(path.join(base, name + '.js'))) continue
+      if (yield* findComponent(name + '.js', bases)) continue
 
       // local module
       if (name === pkg.name) continue
@@ -189,19 +216,21 @@ function* parseMap(opts) {
     return result
   }
 
-  var components = yield glob(path.join(base, '**/*.js'))
-  components = yield components.map(parseComponent)
-  var dependencies = {}
+  for (var i = 0; i < bases.length; i++) {
+    base = bases[i]
+    var components = yield glob(path.join(base, '**/*.js'))
+    components = yield components.map(parseComponent)
 
-  if (opts.self) {
-    dependencies[pkg.name] = yield* resolveModule({
-      name: pkg.name,
-      pkgRoot: root
-    })
-  }
+    if (opts.self) {
+      dependencies[pkg.name] = yield* resolveModule({
+        name: pkg.name,
+        pkgRoot: root
+      })
+    }
 
-  for (var i = 0, len = components.length; i < len; i++) {
-    yield* resolveComponent(dependencies, components[i])
+    for (var j = 0, len = components.length; j < len; j++) {
+      yield* resolveComponent(dependencies, components[j])
+    }
   }
 
   return dependencies

--- a/test/example/browser_modules/v2/main.js
+++ b/test/example/browser_modules/v2/main.js
@@ -1,0 +1,8 @@
+'use strict'
+
+var yen = require('yen')
+var manga = require('ma/nga')
+
+
+exports.$ = yen
+exports.manga = manga

--- a/test/test.compileAll.js
+++ b/test/test.compileAll.js
@@ -12,7 +12,7 @@ var compileAll = require('..').compileAll
 describe('oceanify.compileAll', function() {
   var root = path.join(__dirname, 'example')
 
-  before(function () {
+  beforeEach(function () {
     exec('rm -rf ' + path.join(__dirname, 'example', 'public'))
   })
 
@@ -20,7 +20,8 @@ describe('oceanify.compileAll', function() {
     yield compileAll({
       root: root,
       base: 'components',
-      dest: 'public'
+      dest: 'public',
+      sourceOptions: { root: '/' }
     })
 
     var entries = glob(path.join(root, 'public/**/*.{js,map}')).map(function(entry) {
@@ -35,5 +36,21 @@ describe('oceanify.compileAll', function() {
 
     expect(entries).to.contain('public/crox/1.3.1/build/crox-all.js')
     expect(entries).to.contain('public/crox/1.3.1/build/crox-all.js.map')
+  })
+
+  it('should compile components in muitiple bases', function* () {
+    yield compileAll({
+      root: root,
+      base: ['components', 'browser_modules'],
+      dest: 'public',
+      sourceOptions: { root: '/' }
+    })
+
+    var entries = glob(path.join(root, 'public/**/*.{js,map}')).map(function(entry) {
+      return path.relative(root, entry)
+    })
+
+    expect(entries).to.contain('public/v2/main.js')
+    expect(entries).to.contain('public/v2/main.js.map')
   })
 })


### PR DESCRIPTION
Allow `opts.base` to be an array in oceanify factory and compilation helpers. e.g.

```js
app.use(oceanify({ base: ['browser_modules', 'components'] }))
oceanify.compileAll({ base: ['browser_modules', 'components'] })
oceanify.compileComponent('foo', { base: ['browser_modules', 'components'] })
```

This enables richer infrastructures. 

