### PR TITLE
Breaking: Early import and map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 4
   - 6
 
 install:

--- a/Readme.md
+++ b/Readme.md
@@ -1,29 +1,33 @@
 # Oceanify
 
-Oceanify is yet another solution for browser modularization. It features
-module transformation on the fly and a swift setup.
+Yet another solution for JS and CSS modularization. Oceanify features module
+transformation on the fly and a swift setup.
+
+[中文文档](./Readme.zh.md)
+
 
 ## tl;dr
 
-With Oceanify, you can write web pages and applications in old style but can
-also take advantage of the modular pattern:
+With Oceanify, you can write JS and CSS in an old fashioned manner, whilst be
+able to do both in modular way. Take following HTML for example, the entries
+of JS and CSS is just like the way it was.
 
 ```html
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Oceanify Rocks!</title>
+  <title>An Oceanify Example</title>
   <link rel="stylesheet" type="text/css" href="/main.css">
 </head>
 <body>
-  <h1>Oceanify Rocks!</h1>
+  <h1>An Oceanify Example</h1>
   <script src="/main.js"></script>
 </body>
 </html>
 ```
 
-In `main.js`, you can `require` dependencies:
+Yet in `main.js`, you can `require` dependencies:
 
 ```js
 var $ = require('jquery')
@@ -34,14 +38,14 @@ var nav = require('./nav')
 // setup page with those required components and modules
 ```
 
-And you can do the same in `main.css`:
+And as in `main.css`, you can `@import` dependencies too:
 
 ```css
-@import '/cropper/dist/cropper.css';  /* stylesheets in node_modules */
+@import 'cropper/dist/cropper.css';   /* stylesheets in node_modules */
 @import './nav.css';                  /* stylesheets in components */
 ```
 
-When you want your web pages and application be production ready, simply run:
+When it's time to be production ready, simply run:
 
 ```js
 var co = require('co')
@@ -81,7 +85,7 @@ Oceanify introduces a code organization pattern like below:
         └── support.js
 ```
 
-All the dependencies are at `node_modules` directory. All of project's browser
+External dependencies are at `node_modules` directory. All of project's browser
 code, js and css, are put at `components` folder. In `components`, you can
 `require` and `@import` dependencies from `components` and `node_modules`.
 
@@ -90,7 +94,6 @@ Here's `main.js` would look like:
 ```js
 var $ = require('yen')              // require a module from node_modules
 var Upload = require('arale/upload')  // require other modules in components
-
 
 var upload = new Upload('#btn-upload', { ... })
 

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -1,13 +1,28 @@
 # Oceanify
 
-又一个前端模块化开发解决方案。Oceanify 是一个 Koa/Express 中间件，在 Web 应用中配置使用后，
-前端工程师即可像开发 Node.js 应用一样，使用 CommonJS 编写前端模块，以及使用 NPM 管理前端
-依赖。也可以使用基于 Oceanify 的 [Oceanifier][oceanifier] 等工具来支持纯前端项目开发。
+又一个**前端模块化开发解决方案**。和 SeaJS、RequireJS 等纯前端模块加载器不同，Oceanify
+包含两个部分：中间件和模块加载器。Oceanify 的目标是提供一个整体的前端模块化开发解决方案，
+在功能定位上与 Webpack 和 browserify 相仿，只是解决方式不同。
+
+Oceanify 提供的**中间件**支持 Koa 和 Express，在应用中配置后即可使用。不方便使用 Oceanify
+中间件的前端工程师也可以使用基于 Oceanify 的 [Oceanifier][oceanifier] 工具来支持纯前端
+项目开发。
+
+Oceanify 提供的**模块加载器**采用 CMD 格式包装模块：
+
+```js
+define(${id}, ${dependencies}, function(require, exports, module) {
+  // module code
+})
+```
+
+和 SeaJS 的最大区别是，Oceanify 帮你**自动处理 CMD 包装**，并支持引用 node_modules
+中的依赖。也就是说，你可以**使用 CommonJS 编写前端代码，并且使用 NPM 管理**。
 
 
-## 使用方式
+## 使用
 
-以 Koa 应用为例，在 app.js 中配置 Oceanify 如下：
+以 Koa 应用为例，在 app.js 中配置 Oceanify 中间件如下：
 
 ```js
 const koa = require('koa')
@@ -18,11 +33,11 @@ const app = koa()
 app.use(oceanify())
 ```
 
-配置完毕之后，就可以开始在视图中引入前端模块了。假设有 `views/index.html` 文件，添加首页 JS
-和 CSS 模块方式如下：
+配置完毕之后，就可以开始在页面中引入前端模块了。假设有 `public/index.html` 文件，添加首页
+JS 和 CSS 模块如下：
 
 ```html
-<!-- views/index.jade -->
+<!-- views/index.html -->
 <!doctype html>
 <html>
   <head>
@@ -34,8 +49,9 @@ app.use(oceanify())
 </html>
 ```
 
-`/index.js` 路径对应 `components/index.js` 文件，`?main` 参数则用来告诉 Oceanify，
-这个模块是页面入口。Oceanify 在响应这个模块的时候，将会把模块加载器、依赖信息等一并返回。
+`/index.js` 路径对应 `components/index.js` 文件，`?main` 参数则用来告诉 Oceanify
+中间件，这个模块是入口。中间件在响应这个模块的时候，将会把模块加载器及其配置一并返回。
+
 在 `components/index.js` 中，可以使用相对路径或者绝对路径引用依赖，也可以引用
 node_modules 目录下的模块：
 
@@ -94,18 +110,87 @@ var search = require('./lib/search')
 │   │   └── search.js
 │   ├── index.js
 │   └── index.css
-└── node_modules        # dependencies
-    └── cropper
-        ├── package.json
-        └── dist
-            ├── cropper.css
-            └── cropper.js
+├── node_modules        # dependencies
+│   └── cropper
+│       ├── package.json
+│       └── dist
+│           ├── cropper.css
+│           └── cropper.js
+├── public
+│   └── index.html
+└── app.js
 ```
+
+
+### JS 入口模块
+
+和 Webpack 和 browserify 类似，Oceanify 有 JS 入口模块的概念。在页面中引入 JS 模块的时候，
+需要告诉中间件，现在引入的这个模块是入口模块，请同时返回模块加载器及其配置项。标记入口模块的方式
+是在 JS 路径后面跟上 main 参数：
+
+```html
+<script src="/index.js?main"></script>
+```
+
+这样，Oceanify 中间件在响应这个模块的时候，就会返回如下内容：
+
+```js
+// GET /index.js?main
+(function(global) {
+  // loader code
+  global.oceanify = { ... }
+})(this)
+
+oceanify.config({
+  // loader config
+})
+
+// 为支持低版本 IE，这里使用 oceanify['import'] 而非 oceanify.import，后者会报语法错误
+oceanify['import']('index')
+```
+
+当然，也可以选择不使用这种略显嬉皮的方式，而是像其他传统模块加载器那样自行引入模块加载器和配置，
+继而引入入口模块：
+
+```html
+<script src="/loader.js"></script>
+<script>
+oceanify.config(${loaderConfig})
+oceanify['import']('index')
+</script>
+```
+
+
+### 缓存
+
+和 Webpack 或者 browerify 将模块依赖打包成一个文件或者按尺寸分割成多个包不同，Oceanify
+天生是按模块组织代码的。在默认情况下，外部依赖会被编译，按模块名打包，放到缓存目录，从而加速开发
+时的体验。所以一般我们推荐 Oceanify 中间件和静态文件服务中间件，比如 koa-static，配合使用：
+
+```js
+const koa = require('koa')
+const oceanify = require('oceanify')
+const serve = require('koa-static')
+
+const app = koa()
+
+app.use(serve('public'))
+app.use(oceanify())
+```
+
+静态文件服务中间件需要在 Oceanify 中间件之前，这样才能拦截到 Oceanify 中间件生成的外部依赖
+缓存，以及 Source Map 等。默认情况下，Oceanify 中间件生成的缓存文件会在 public 目录下，
+可以使用 opts.dest 配置，详见下文配置项说明。
 
 
 ## 配置
 
-在初始化 Oceanify 的时候，可以传入配置项：
+Oceanify 的中间件和模块加载器均提供丰富配置项以满足各种开发需要，尤以中间件配置项为多。
+
+
+### 中间件配置
+
+在初始化 Oceanify 中间件的时候，可以传入配置项：
 
 ```js
 app.use(oceanify({ /* 配置项 */ }))
@@ -114,9 +199,21 @@ app.use(oceanify({ /* 配置项 */ }))
 
 ### opts.cacheExcept
 
-在默认情况下，Oceanify 在响应请求的时候遇到 node_modules 中的模块，就会编译它，打包它的
-相对依赖，将编译结果存放到 `public`，从而加速外部依赖的响应速度。需要调试某个外部依赖的时候，
-使用 opts.cacheExcept 即可关闭特定依赖的缓存逻辑：
+在默认情况下，中间件在响应请求的时候遇到 node_modules 中的模块，就会编译它，打包同目录下的
+相对依赖，将编译结果存放到 `public`，从而加速外部依赖的响应速度。例如 yen 模块的源码中包含
+两个文件：
+
+- yen/index.js
+- yen/events.js
+
+在前端 `require('yen')` 的时候，模块加载器根据配置，会映射路径到 yen/1.4.0/index.js。
+中间件接到请求后，则会根据 dependenciesMap 中存储的路径信息，找到 yen/1.4.0/index.js
+对应的路径为 node_modules/yen/index.js。在响应这个请求的同时，会开始编译 yen；并且由于
+index.js 中 `require('./events')`，中间件在编译时就会把两个模块合到一起。这样下次请求
+yen/1.4.0/index.js 的时候，浏览器发起一次请求就够了。
+
+需要调试某个外部依赖时，预编译就显得画蛇添足，可以使用 opts.cacheExcept 告诉中间件，不要缓存
+特定外部依赖：
 
 ```js
 // 不缓存 yen
@@ -134,7 +231,7 @@ app.use(oceanify({ cacheExcept: '*' }))
 
 ### opts.cachePersist
 
-在默认情况下，Oceanify 会在每次初始化的时候清空缓存目录，可以通过 opts.cachePersist 配置项
+在默认情况下，中间件在每次初始化的时候会清空缓存目录。可以通过 opts.cachePersist 配置项
 来关闭它：
 
 ```js
@@ -146,7 +243,7 @@ app.use(oceanify({ cachePersist: true }))
 
 ### opts.dependenciesMap
 
-Oceanify 内部使用 dependenciesMap 来维护模块的依赖关系，在一些特殊情况下，我们需要传入其他
+中间件内部使用 dependenciesMap 来维护模块的依赖关系，在一些特殊情况下，我们需要传入其他
 项目的 dependenciesMap：
 
 ```js
@@ -159,7 +256,7 @@ app.use(oceanify({ dependenciesMap }))
 
 ### opts.dest
 
-Oceanify 默认会将模块缓存到 public 目录，可以使用 opts.dest 配置它：
+中间件默认会将模块缓存到 public 目录，可以使用 opts.dest 配置它：
 
 ```js
 app.use(oceanify({ dest: '.oceanify-cache' }))
@@ -170,13 +267,13 @@ app.use(oceanify({ dest: '.oceanify-cache' }))
 
 ### opts.express
 
-默认返回的中间件为 Koa 格式：
+中间件初始化的时候默认返回的格式为 Koa 格式：
 
 ```js
 function* (next) {}
 ```
 
-可以使用 opts.express 要求 Oceanify 返回 Express 格式的中间件：
+可以使用 opts.express 配置返回格式为 Express 格式：
 
 ```js
 app.use(oceanify({ express: true }))
@@ -187,42 +284,13 @@ app.use(oceanify({ express: true }))
 
 ### opts.loaderConfig
 
-通过 `?main` 指定入口模块之后，Oceanify 会返回模块加载器及其配置，因此默认情况下模块加载器的
-配置入口是隐藏的，在入口模块的响应内容中就指定了：
+在使用嬉皮方式引入 JS 入口模块的时候：
 
-```js
-// http://example.com/index.js?main
-(function(global) {
-  // loader code
-  global.oceanify = { ... }
-})(this)
-
-oceanify.config({
-  base: '',
-  map: '',
-  modules: {},
-  dependencies: {}
-})
+```html
+<script src="/index.js?main"></script>
 ```
 
-其中 modules 和 dependencies 是 Oceanify 在初始化的时候通过分析 components 和
-node_modules 目录结构生成的；base 和 map，则开发用户配置。
-
-可以使用 opts.loaderConfig 来配置这两个配置项：
-
-```js
-loaderConfig: {
-  base: 'http://cdn.example.com',
-  map: { ... }
-}
-```
-
-详细 opts.loaderConfig 配置解析见下文。
-
-
-#### opts.loaderConfig.base
-
-可以使用 opts.loaderConfig.base 配置模块记载器的根路径，例如：
+我们无法在前端页面配置模块加载器，这时候可以通过 opts.loaderConfig 传递配置项：
 
 ```js
 app.use(oceanify({
@@ -232,73 +300,23 @@ app.use(oceanify({
 }))
 ```
 
-在默认情况下，Oceanify 的模块加载器将以 location.origin 为 base，对应关系如下：
-
-| module id | module.uri { base: '' }     | module.uri { base: 'http://cdn.example.com' } |
-|-----------|-----------------------------|-----------------------------------------------|
-| index.js  | http://example.com/index.js | http://cdn.example.com/index.js               |
-
-
-#### opts.loaderConfig.map
-
-可以使用 opts.loaderConfig.map 配置模块映射，从而修改某些模块的下载地址（module.uri）：
-
-```js
-app.use(oceanify({
-  loaderConfig: {
-    map: {
-      jquery: 'https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js'
-    }
-  }
-}))
-```
-
-也可以写正则：
-
-```js
-app.use(oceanify({
-  loaderConfig: {
-    base: 'http://cdn.example.com',
-    map: {
-      '(templates|creatives)/(\\d+)': '/$1/$2.js'
-    }
-  }
-}))
-```
-
-上述例子将所有 templates/${id} 和 creations/${id} 的模块地址映射到本地，而不是 base
-里配置的 <http://cdn.example.com>。因此 Oceanify 会去 <http://${loaction.origin}/templates/${id}.js>
-下载模块代码，而非 <http://cdn.example.com/templates/${id}.js>。
-
-当然，因为 map 中的 pattern 默认从 module id 行首开始匹配，上述例子不写正则也可以实现：
-
-```js
-app.use(oceanify({
-  loaderConfig: {
-    base: 'http://cdn.example.com',
-    map: {
-      creatives: '/creatives',
-      templates: '/templates'
-    }
-  }
-}))
-```
+详细的配置项文档见“模块加载器配置”章节。
 
 
 ### opts.paths
 
-Oceanify 默认从 components 目录查找组件源码，可以使用 opts.paths 配置这一目录：
+中间件默认从 components 目录查找组件源码，可以使用 opts.paths 配置这一目录：
 
 ```js
 app.use(oceanify({ paths: 'browser_modules' }))
 ```
 
-opts.paths 支持传入数组，从而告诉 Oceanify 尝试从多个组件目录查找组件。
+opts.paths 支持传入数组，从而告诉中间件尝试从多个组件目录查找组件。
 
 
 ### opts.root
 
-Oceanify 默认以 `process.cwd()` 为根目录，通常与项目根目录一致。遇到不一致的情况，可以使用
+中间件默认以 `process.cwd()` 为根目录，通常与项目根目录一致。遇到不一致的情况，可以使用
 opts.root 来配置根目录，从而确保 opts.paths 都能正确查找：
 
 ```js
@@ -314,7 +332,7 @@ app.use(oceanify({ root: __dirname }))
 运行 Oceanify，开启 opts.serveSelf 之后就会对应 `/yen/1.4.0/index.js` 到
 `./index.js`。
 
-一般 Web 应用中不需要使用到这一功能，切勿开启。
+一般 Web 应用中不需要使用到这一功能，**切勿开启**。
 
 默认值：`false`。
 
@@ -336,10 +354,100 @@ GET /components/lib/aside.js
 GET /node_modules/cropper/dist/cropper.js
 ```
 
-不建议线上环境开启这项功能，会造成源码泄漏。我们将在 oceanify.compileAll 章节深入讨论
+**不建议线上环境开启这项功能**，会造成源码泄漏。我们将在 oceanify.compileAll 章节深入讨论
 Source Map 以及 Oceanify 的支持方式。
 
 默认值：`false`。
+
+
+### 模块加载器配置
+
+模块加载器提供配置项如下：
+
+```js
+loaderConfig: {
+  base: 'http://cdn.example.com',
+  map: { ... }
+}
+```
+
+使用嬉皮方式引入 JS 入口模块的时候，需要通过中间接配置项传递模块加载器的配置：
+
+```js
+app.use(oceanify({
+  loaderConfig: { ... }
+}))
+```
+
+使用传统方式，则在页面中调用 oceanify.config 即可：
+
+```js
+oceanify.config({ ... })
+```
+
+下文中示例一律采用如下格式：
+
+```js
+loaderConfig: { ... }
+```
+
+
+#### loaderConfig.base
+
+模块加载器默认从 location.origin 下载模块，即传统模块加载器中的 base 概念。可以使用
+opts.loaderConfig.base 配置这一路径，例如：
+
+```js
+loaderConfig: {
+  base: 'http://cdn.example.com'
+}
+```
+
+配置前后的效果对应关系如下：
+
+| module id | module.uri { base: '' }     | module.uri { base: 'http://cdn.example.com' } |
+|-----------|-----------------------------|-----------------------------------------------|
+| index.js  | http://example.com/index.js | http://cdn.example.com/index.js               |
+
+
+#### loaderConfig.map
+
+可以使用 opts.loaderConfig.map 配置模块映射，从而修改某些模块的下载地址（module.uri）：
+
+```js
+loaderConfig: {
+  map: {
+    jquery: 'https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js'
+  }
+}
+```
+
+也可以写正则：
+
+```js
+loaderConfig: {
+  base: 'http://cdn.example.com',
+  map: {
+    '(templates|creatives)/(\\d+)': '/$1/$2.js'
+  }
+}
+```
+
+上述例子将所有 templates/${id} 和 creations/${id} 的模块地址映射到本地，而不是 base
+里配置的 <http://cdn.example.com>。因此 Oceanify 会去 <http://${loaction.origin}/templates/${id}.js>
+下载模块代码，而非 <http://cdn.example.com/templates/${id}.js>。
+
+当然，因为 map 中的 pattern 默认从 module id 行首开始匹配，上述例子不写正则也可以实现：
+
+```js
+loaderConfig: {
+  base: 'http://cdn.example.com',
+  map: {
+    creatives: '/creatives',
+    templates: '/templates'
+  }
+}
+```
 
 
 ## 部署

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -1,0 +1,277 @@
+# Oceanify
+
+又一个前端模块化开发解决方案。Oceanify 是一个 Koa/Express 中间件，在 Web 应用中配置使用后，
+前端工程师即可像开发 Node.js 应用一样，使用 CommonJS 编写前端模块，以及使用 NPM 管理前端
+依赖。也可以使用基于 Oceanify 的 [Oceanifier][oceanifier] 等工具来支持纯前端项目开发。
+
+
+## 使用方式
+
+以 Koa 应用为例，在 app.js 中配置 Oceanify 如下：
+
+```js
+const koa = require('koa')
+const oceanify = require('oceanify')
+
+const app = koa()
+
+app.use(oceanify())
+```
+
+配置完毕之后，就可以开始在视图中引入前端模块了。假设有 `views/index.jade` 文件，添加首页 JS
+和 CSS 模块方式如下：
+
+```jade
+// views/index.jade
+doctype html
+html
+  head
+    link(rel='stylesheet', href='/index.css')
+  body
+    script(src='/index.js?main')
+```
+
+`/index.js` 路径将对应 `components/index.js` 文件，`?main` 参数则用来告诉 Oceanify，
+这个模块是页面入口。Oceanify 在响应这个模块的时候，将会把模块加载器、依赖信息等一并返回。
+在 `components/index.js` 中，可以使用相对路径或者绝对路径引用依赖，也可以引用
+node_modules 目录下的模块：
+
+```js
+// components/index.js
+'use strict'
+
+// 外部依赖
+// cropper => node_modules/cropper/dist/cropper.js
+var Cropper = require('jquery')
+
+// 绝对路径
+// lib/aside => components/lib/aside.js
+var aside = require('lib/aside')
+
+// 相对路径
+// path.resolve('index', './lib/search') => components/lib/search.js
+var search = require('./lib/search')
+```
+
+`/index.css` 路径将对应 `components/index.css` 文件。因为 CSS 模块加载全部在后端处理，
+不涉及前端模块加载器，因此入口模块不需要配置 `?main` 参数。在 `components/index.css` 中，
+可以使用相对路径或者绝对路径引用依赖，也可以引用 node_modules 目录下的模块的 CSS：
+
+```css
+/* components/index.css */
+
+/*
+ * 外部依赖
+ * cropper/dist/cropper.css => node_modules/cropper/dist/cropper.css
+ */
+@import "cropper/dist/cropper.css";
+
+/*
+ * 绝对路径
+ * lib/aside => components/lib/aside.css
+ */
+@import "lib/aside.css";
+
+/*
+ * 相对路径
+ * path.resolve('index.css', './lib/search.css') => components/lib/search.css
+ */
+@import "./lib/search.css";
+```
+
+上述示例应用的结构为：
+
+```bash
+.
+├── components          # browser modules
+│   ├── lib
+│   │   ├── aside.css
+│   │   ├── aside.js
+│   │   ├── search.css
+│   │   └── search.js
+│   ├── index.js
+│   └── index.css
+└── node_modules        # dependencies
+    └── cropper
+        ├── package.json
+        └── dist
+            ├── cropper.css
+            └── cropper.js
+```
+
+
+## 配置
+
+在初始化 Oceanify 的时候，可以传入配置项：
+
+```js
+app.use(oceanify({ /* 配置项 */ }))
+```
+
+
+### opts.cacheExcept
+
+在默认情况下，Oceanify 在响应请求的时候遇到 node_modules 中的模块，就会编译它，打包它的
+相对依赖，将编译结果存放到 `public`，从而加速外部依赖的响应速度。需要调试某个外部依赖的时候，
+使用 opts.cacheExcept 即可关闭特定依赖的缓存逻辑：
+
+```js
+// 不缓存 yen
+app.use(oceanify({ cacheExcept: 'yen' }))
+
+// 不缓存 yen 和 jquery
+app.use(oceanify({ cacheExcept: ['yen', 'jquery'] }))
+
+// 关闭所有缓存
+app.use(oceanify({ cacheExcept: '*' }))
+```
+
+默认值：`[]`。
+
+
+### opts.cachePersist
+
+在默认情况下，Oceanify 会在每次初始化的时候清空缓存目录，可以通过 opts.cachePersist 配置项
+来关闭它：
+
+```js
+app.use(oceanify({ cachePersist: true }))
+```
+
+默认值：`false`。
+
+
+### opts.dependenciesMap
+
+Oceanify 内部使用 dependenciesMap 来维护模块的依赖关系，在一些特殊情况下，我们需要传入其他
+项目的 dependenciesMap：
+
+```js
+const dependenciessMap = yield fetch('http://example.com/dependenciesMap.json')
+app.use(oceanify({ dependenciesMap }))
+```
+
+默认值：`null`。
+
+
+### opts.dest
+
+Oceanify 默认会将模块缓存到 public 目录，可以使用 opts.dest 配置它：
+
+```js
+app.use(oceanify({ dest: '.oceanify-cache' }))
+```
+
+默认值：`public`。
+
+
+### opts.express
+
+默认返回的中间件为 Koa 格式：
+
+```js
+function* (next) {}
+```
+
+可以使用 opts.express 要求 Oceanify 返回 Express 格式的中间件：
+
+```js
+app.use(oceanify({ express: true }))
+```
+
+默认值：`false`。
+
+
+### opts.loaderConfig
+
+可以使用 opts.loaderConfig 来配置 Oceanify 的模块加载器，例如：
+
+```js
+app.use(oceanify({
+  loaderConfig: {
+    base: 'http://cdn.example.com',
+    map: { users: '/users' }
+  }
+}))
+```
+
+上述配置告诉模块加载器去 http://cdn.example.com 下载模块，users 模块仍然从 `/` 下载。
+
+默认值：`{}`。
+
+
+#### opts.loaderConfig.base
+
+#### opts.loaderConfig.dependenciesMap
+
+#### opts.loaderConfig.map
+
+
+### opts.paths
+
+Oceanify 默认从 components 目录查找组件源码，可以使用 opts.paths 配置这一目录：
+
+```js
+app.use(oceanify({ paths: 'browser_modules' }))
+```
+
+opts.paths 支持传入数组，从而告诉 Oceanify 尝试从多个组件目录查找组件。
+
+
+### opts.root
+
+Oceanify 默认以 `process.cwd()` 为根目录，通常与项目根目录一致。遇到不一致的情况，可以使用
+opts.root 来配置根目录，从而确保 opts.paths 都能正确查找：
+
+```js
+app.use(oceanify({ root: __dirname }))
+```
+
+默认值：`process.cwd()`
+
+
+### opts.serveSelf
+
+使用 Oceanify 开发前端模块的时候，需要响应项目目录下的内容。以 yen 为例，在 yen 项目目录下
+运行 Oceanify，开启 opts.serveSelf 之后就会对应 `/yen/1.4.0/index.js` 到
+`./index.js`。
+
+一般 Web 应用中不需要使用到这一功能，切勿开启。
+
+默认值：`false`。
+
+
+### opts.serveSource
+
+可以通过 opts.serveSource 告诉 Oceanify 响应源码请求，从而让 devtools 正常展现
+Source Map：
+
+```js
+app.use(oceanify.use({ serveSource: true }))
+```
+
+开启 opts.serveSource 之后，Oceanify 将会响应如下请求：
+
+```
+GET /components/index.js
+GET /components/lib/aside.js
+GET /node_modules/cropper/dist/cropper.js
+```
+
+不建议线上环境开启这项功能，会造成源码泄漏。有关 Source Map，在 oceanify.compileAll 章节
+我们将深入讨论。
+
+默认值：`false`。
+
+
+## 部署
+
+TODO
+
+
+## 模块加载器
+
+TODO
+
+
+[oceanifier]: https://github.com/erzu/oceanifier

--- a/bin/compileModule.js
+++ b/bin/compileModule.js
@@ -11,11 +11,11 @@ const compileAll = require('../lib/compileAll')
 const argv = minimist(process.argv.slice(2))
 
 
-console.log('Compiling %s from %s into %s', argv.id, argv.base, argv.dest)
+console.log('Compiling %s from %s into %s', argv.id, argv.paths, argv.dest)
 
 co(compileAll.compileModule(argv.id, {
-  base: argv.base,
   dest: argv.dest,
+  paths: argv.paths,
   sourceRoot: argv['source-root'] || '/'
 }))
   .then(function() {

--- a/index.js
+++ b/index.js
@@ -108,9 +108,7 @@ function oceanify(opts = {}) {
   const encoding = 'utf8'
   const root = opts.root || process.cwd()
   const dest = path.resolve(root, opts.dest || 'public')
-  const cacheExceptions = typeof opts.cacheExcept === 'string'
-    ? [opts.cacheExcept]
-    : opts.cacheExcept || []
+  const cacheExceptions = [].concat(opts.cacheExcept)
   const serveSource = opts.serveSource
   const loaderConfig = opts.loaderConfig || {}
   const paths = [].concat(opts.paths || 'components').map(function(dir) {

--- a/index.js
+++ b/index.js
@@ -223,8 +223,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
     return define(id, dependencies, factory)
   }
 
-
-  const importer = postcss().use(atImport({ path: [root] }))
+  const importer = postcss().use(atImport({ path: paths }))
   const prefixer = postcss().use(autoprefixer())
 
   function* readStyle(id) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ const loaderSource = fs.readFileSync(loaderPath, 'utf8')
 const loaderStats = fs.statSync(loaderPath)
 
 const RE_EXT = /(\.(?:css|js))$/i
-const RE_MAIN = /\/(?:main|runner)\.js$/
 const RE_ASSET_EXT = /\.(?:gif|jpg|jpeg|png|svg|swf|ico)$/i
 
 const exists = fs.exists
@@ -337,7 +336,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
       if (res.headerSent) return next()
 
       const id = req.path.slice(1)
-      const isMain = RE_MAIN.test(req.path) || 'main' in req.query
+      const isMain = 'main' in req.query
 
       co(readAsset(id, isMain)).then(function(result) {
         if (result) {
@@ -361,7 +360,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
       if (this.headerSent) return yield next
 
       const id = this.path.slice(1)
-      const isMain = RE_MAIN.test(this.path) || 'main' in this.query
+      const isMain = 'main' in this.query
       const result = yield* readAsset(id, isMain)
 
       if (result) {

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function parseId(id, system) {
  * @param {DependenciesMap} [opts.dependenciesMap=null]   Dependencies map
  * @param {string}          [opts.dest=public]            Cache destination
  * @param {boolean}         [opts.express=false]          Express middleware
- * @param {Object}          [opts.loaderConfig={}]        Loader config     
+ * @param {Object}          [opts.loaderConfig={}]        Loader config
  * @param {string|string[]} [opts.paths=components]       Base directory name or path
  * @param {string}          [opts.root=process.cwd()]     Override current working directory
  * @param {boolean}         [opts.serveSelf=false]        Include host module itself
@@ -191,7 +191,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
       'Cache-Control': 'max-age=0',
       'Content-Type': 'application/javascript',
       ETag: crypto.createHash('md5').update(content).digest('hex'),
-      'Last-Modified': stats.mtime
+      'Last-Modified': stats.mtime.toJSON()
     }]
   }
 
@@ -258,7 +258,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
     }
 
     return [content, {
-      'Last-Modified': (yield lstat(fpath)).mtime
+      'Last-Modified': (yield lstat(fpath)).mtime.toJSON()
     }]
   }
 
@@ -275,11 +275,12 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
     const fpath = path.join(root, id)
 
     if (yield exists(fpath)) {
-      const content = yield readFile(fpath, encoding)
-      const stats = lstat(fpath)
+      const [ content, stats ] = yield [
+        readFile(fpath, encoding), lstat(fpath)
+      ]
 
       return [content, {
-        'Last-Modified': stats.mtime
+        'Last-Modified': stats.mtime.toJSON()
       }]
     }
   }
@@ -292,7 +293,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
 
     if (id === 'loader.js') {
       result = [loaderSource, {
-        'Last-Modified': loaderStats.mtime
+        'Last-Modified': loaderStats.mtime.toJSON()
       }]
     }
     else if (id === 'dependenciesMap.json') {
@@ -300,7 +301,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
       result = [JSON.stringify(dependenciesMap, function(key, value) {
         return key === 'dir' ? undefined : value
       }), {
-        'Last-Modified': loaderStats.mtime
+        'Last-Modified': loaderStats.mtime.toJSON()
       }]
     }
     else if (serveSource && isSource(id)) {
@@ -317,7 +318,7 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
       const stats = yield lstat(fpath)
 
       result = [content, {
-        'Last-Modified': stats.mtime
+        'Last-Modified': stats.mtime.toJSON()
       }]
     }
 

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ function oceanify(opts = {}) {
     return `${loader}
 oceanify.config(${JSON.stringify(loaderConfig)})
 ${content}
-oceanify['import'](${JSON.stringify(entries)})
+oceanify["import"](${JSON.stringify(entries)})
 `
   }
 

--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -7,10 +7,8 @@
 const co = require('co')
 const path = require('path')
 const crypto = require('crypto')
-const objectAssign = require('object-assign')
 const _spawn = require('child_process').spawn
 const debug = require('debug')('oceanify')
-const semver = require('semver')
 
 const findModule = require('./findModule')
 const fs = require('./fs')
@@ -30,7 +28,7 @@ function spawn(command, args, opts) {
 
     proc.on('exit', function(code) {
       if (code === 0) resolve()
-      else reject()
+      else reject(new Error(code))
     })
   })
 }
@@ -78,10 +76,6 @@ function* precompile(mod, opts) {
     '--source-root', '/'
   ]
 
-  if (semver.lt(process.versions.node, '1.0.0')) {
-    args.unshift('--harmony')
-  }
-
   yield spawn(process.argv[0], args, {
     stdio: 'inherit'
   })
@@ -95,24 +89,26 @@ function* precompile(mod, opts) {
 
 /**
  * Cache
- * @constructor
- * @param {Object} opts
- * @param {string} opts.dest     Where to store the cached files
- * @param {string} opts.encoding The encoding of the source files
  */
-function Cache(opts) {
-  const dest = opts.dest
+class Cache {
+  /**
+   * @constructor
+   * @param {Object} opts
+   * @param {string} opts.dest     Where to store the cached files
+   * @param {string} opts.encoding The encoding of the source files
+   */
+  constructor(opts) {
+    const dest = opts.dest
 
-  if (!dest) {
-    throw new Error('Please specify the cache destination folder.')
+    if (!dest) {
+      throw new Error('Please specify the cache destination folder.')
+    }
+
+    this.dest = dest
+    this.encoding = opts.encoding
   }
 
-  this.dest = dest
-  this.encoding = opts.encoding
-}
-
-objectAssign(Cache.prototype, {
-  read: function* (id, source) {
+  * read(id, source) {
     const checksum = crypto.createHash('md5').update(source).digest('hex')
     const cacheName = id.replace(RE_EXT, '-' + checksum + '$1')
     const fpath = path.join(this.dest, cacheName)
@@ -120,9 +116,9 @@ objectAssign(Cache.prototype, {
     if (yield exists(fpath)) {
       return yield readFile(fpath, this.encoding)
     }
-  },
+  }
 
-  write: function* (id, source, content) {
+  * write(id, source, content) {
     const md5 = crypto.createHash('md5').update(source)
     const cacheId = id.replace(RE_EXT, '-' + md5.digest('hex') + '$1')
     const fpath = path.join(this.dest, cacheId)
@@ -130,16 +126,16 @@ objectAssign(Cache.prototype, {
     yield this.remove(id, cacheId)
     yield mkdirp(path.dirname(fpath))
     yield writeFile(fpath, content)
-  },
+  }
 
-  writeFile: function* (id, content) {
+  * writeFile(id, content) {
     const fpath = path.join(this.dest, id)
 
     yield mkdirp(path.dirname(fpath))
     yield writeFile(fpath, content)
-  },
+  }
 
-  remove: function* (id) {
+  * remove(id) {
     const fname = path.basename(id)
     const dir = path.join(this.dest, path.dirname(id))
 
@@ -153,16 +149,16 @@ objectAssign(Cache.prototype, {
         yield unlink(path.join(dir, entry))
       }
     }
-  },
+  }
 
-  removeAll: function* () {
+  * removeAll() {
     const dest = this.dest
 
     debug('rm -rf ' + dest)
     yield spawn('rm', [ '-rf', dest ], { stdio: 'inherit' })
-  },
+  }
 
-  precompile: function(mod, opts) {
+  precompile(mod, opts) {
     const system = opts.system
     const dest = this.dest
 
@@ -190,7 +186,7 @@ objectAssign(Cache.prototype, {
       console.error(err.stack)
     })
   }
-})
+}
 
 
 module.exports = Cache

--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -71,8 +71,8 @@ function* precompile(mod, opts) {
   const args = [
     path.join(__dirname, '../bin/compileModule.js'),
     '--id', path.join(mod.name, mod.version, mod.entry.replace(RE_EXT, '')),
-    '--base', fpath,
     '--dest', dest,
+    '--paths', fpath,
     '--source-root', '/'
   ]
 

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -204,6 +204,11 @@ function* _bundle(main, opts) {
 
   function* appendModule(name) {
     var data = findModule(route, dependenciesMap, requiredMap)
+
+    if (!data) {
+      throw new Error(`Cannot find module ${name}`)
+    }
+
     var id = path.join(name, data.version, data.main.replace(/\.js$/, ''))
     var pkgBase = name.split('/').reduce(function(result) {
       return path.resolve(result, '..')

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -171,10 +171,15 @@ function* _bundle(main, opts) {
     }
 
     fpath = fpath || path.join(paths[0], sourceId + '.js')
-    toplevel = UglifyJS.parse(define(id, dependencies, factory), {
-      filename: path.relative(root, fpath),
-      toplevel: toplevel
-    })
+
+    try {
+      toplevel = UglifyJS.parse(define(id, dependencies, factory), {
+        filename: path.relative(root, fpath),
+        toplevel: toplevel
+      })
+    } catch (err) {
+      throw new Error(err.toString())
+    }
 
     yield* satisfy({ id: id, dependencies: dependencies })
   }
@@ -341,7 +346,8 @@ function* compileAll(opts = {}) {
 
   for (let i = 0; i < paths.length; i++) {
     const currentPath = paths[i]
-    const entries = yield glob(path.join(currentPath, '**/*.js'))
+    const pattern = path.join(currentPath, '!(node_modules)/**/*.js')
+    const entries = yield glob(pattern, { cwd: currentPath })
 
     if (!entries.length) {
       console.error('Found no entries to compile in %s', currentPath)
@@ -411,10 +417,18 @@ function* compileComponentPlain(id, opts) {
   const fpath = yield findComponent(id + '.js', paths)
   const content = yield readFile(fpath, 'utf8')
   const dependencies = matchRequire.findAll(content)
+  let toplevel
 
-  const toplevel = UglifyJS.parse(define(id, dependencies, content), {
-    filename: path.relative(root, fpath)
-  })
+  try {
+    toplevel = UglifyJS.parse(define(id, dependencies, content), {
+      filename: path.relative(root, fpath)
+    })
+  } catch (e) {
+    // UglifyJS uses a custom Error class which by default will not reveal
+    // syntax error details in message property. We need to call the customized
+    // toString method instead.
+    throw new Error(e.toString())
+  }
 
   const result = _process(id, toplevel, opts.sourceRoot)
   const dest = opts.dest && path.resolve(root, opts.dest)
@@ -462,7 +476,7 @@ function* compileComponent(id, opts) {
   }
 
   let factory = opts.factory
-  
+
   if (!factory) {
     const fpath = yield findComponent(id + '.js', paths)
     factory = yield readFile(fpath, 'utf8')
@@ -524,12 +538,12 @@ oceanify.import(${JSON.stringify(id.replace(/\.js$/, ''))})
  * @yield {ProcessResult}
  */
 function* compileModule(id, opts) {
-  opts = Object.assign({ 
+  opts = Object.assign({
     root: process.cwd(),
     paths: 'node_modules'
   }, opts)
   const { root, paths } = opts
-  const currentPath = path.resolve(root, Array.isArray(paths) ? paths[0] : paths) 
+  const currentPath = path.resolve(root, Array.isArray(paths) ? paths[0] : paths)
 
   const toplevel = yield* _bundle(id, {
     root: root,

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -307,29 +307,28 @@ function* _compileFile(id, opts) {
  * @param {string}          [opts.root=process.cwd()]       Current working directory
  * @param {string}          [opts.sourceRoot]               The source root
  */
-function* compileAll(opts) {
-  opts = opts || {}
-  var root = opts.root || process.cwd()
-  var dest = path.resolve(root, opts.dest || 'public')
-  var match = opts.match || '**/main.js'
-  var sourceRoot = opts.sourceRoot
-  var bases = [].concat(opts.base || 'components').map(function(base) {
+function* compileAll(opts = {}) {
+  const root = opts.root || process.cwd()
+  const dest = path.resolve(root, opts.dest || 'public')
+  const match = opts.match || '**/main.js'
+  const sourceRoot = opts.sourceRoot
+  const bases = [].concat(opts.base || 'components').map(function(base) {
     return path.resolve(root, base)
   })
 
-  var dependenciesMap = yield* parseMap({ root: root, base: bases, dest: dest })
-  var compiled = {}
+  const dependenciesMap = yield* parseMap({ root: root, base: bases, dest: dest })
+  const doneModules = {}
 
   function* walk(deps) {
-    for (var name in deps) {
-      var mod = deps[name]
-      var versions = compiled[name] || (compiled[name] = {})
-      var main = (mod.main || 'index').replace(/\.js$/, '')
-      var pkgBase = name.split('/').reduce(function(result) {
+    for (const name in deps) {
+      const mod = deps[name]
+      const doneModule = doneModules[name] || (doneModules[name] = {})
+      const main = (mod.main || 'index').replace(/\.js$/, '')
+      const pkgBase = name.split('/').reduce(function(result) {
         return path.resolve(result, '..')
       }, mod.dir)
 
-      if (versions[mod.version]) continue
+      if (doneModule[mod.version]) continue
 
       yield* compileModule(path.join(name, mod.version, main), {
         root: root,
@@ -345,15 +344,15 @@ function* compileAll(opts) {
   yield* walk(dependenciesMap)
 
   for (let i = 0; i < bases.length; i++) {
-    let base = bases[i]
-    let entries = yield glob(path.join(base, '**/*.js'))
+    const base = bases[i]
+    const entries = yield glob(path.join(base, '**/*.js'))
 
     if (!entries.length) {
       console.error('Found no entries to compile in %s', base)
     }
 
     for (let j = 0, len = entries.length; j < len; j++) {
-      let id = path.relative(base, entries[j]).replace(/\.js$/, '')
+      const id = path.relative(base, entries[j]).replace(/\.js$/, '')
 
       if (minimatch(id + '.js', match)) {
         yield* compileComponent(id, {
@@ -483,18 +482,15 @@ function* compileComponent(id, opts) {
   var requiredMap = {}
   var toplevel = yield* parseLoader()
   var bundleOpts = {
-    root: root,
-    bases: bases,
-    dependencies: dependencies,
-    factory: factory,
-    toplevel: toplevel
+    root,
+    bases,
+    dependencies,
+    factory,
+    toplevel
   }
 
   if (includeModules) {
-    Object.assign(bundleOpts, {
-      dependenciesMap: dependenciesMap,
-      requiredMap: requiredMap
-    })
+    Object.assign(bundleOpts, { dependenciesMap, requiredMap })
   }
 
   toplevel = yield* _bundle(id, bundleOpts)

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -308,7 +308,7 @@ function* _compileFile(id, { dest, js, map }) {
  *
  * @param {Object}           opts
  * @param {string}          [opts.dest=public]              The destintation directory
- * @param {string}          [opts.match={**\/main.js}]      The match pattern to find the components to compile
+ * @param {string}          [opts.match=null]      The match pattern to find the components to compile
  * @param {string|string[]} [opts.paths=components]         The base directory to find the sources
  * @param {string}          [opts.root=process.cwd()]       Current working directory
  * @param {string}          [opts.sourceRoot]               The source root
@@ -316,11 +316,15 @@ function* _compileFile(id, { dest, js, map }) {
 function* compileAll(opts = {}) {
   const root = opts.root || process.cwd()
   const dest = path.resolve(root, opts.dest || 'public')
-  const match = opts.match || '**/main.js'
+  const match = opts.match
   const sourceRoot = opts.sourceRoot
   const paths = [].concat(opts.paths || 'components').map(function(dir) {
     return path.resolve(root, dir)
   })
+
+  if (!match) {
+    throw new Error('Please specify main modules with opts.match')
+  }
 
   const dependenciesMap = yield* parseMap({ root, paths, dest })
   const doneModules = {}

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -346,7 +346,7 @@ function* compileAll(opts = {}) {
 
   for (let i = 0; i < paths.length; i++) {
     const currentPath = paths[i]
-    const pattern = path.join(currentPath, '!(node_modules)/**/*.js')
+    const pattern = path.join(currentPath, '{*.js,!(node_modules)/**/*.js}')
     const entries = yield glob(pattern, { cwd: currentPath })
 
     if (!entries.length) {

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -242,22 +242,22 @@ function* _bundle(main, opts) {
  */
 function _process(id, ast, sourceRoot) {
   /* eslint-disable camelcase */
-  var compressor = new UglifyJS.Compressor()
+  const compressor = new UglifyJS.Compressor()
 
   deheredoc(ast)
   ast.figure_out_scope()
 
-  var compressed = ast.transform(compressor)
+  const compressed = ast.transform(compressor)
 
   compressed.figure_out_scope()
   compressed.compute_char_frequency()
   compressed.mangle_names()
 
-  var sourceMap = new UglifyJS.SourceMap({
+  const sourceMap = new UglifyJS.SourceMap({
     file: id + '.js',
     root: sourceRoot
   })
-  var stream = new UglifyJS.OutputStream({
+  const stream = new UglifyJS.OutputStream({
     ascii_only: true,
     source_map: sourceMap
   })
@@ -279,14 +279,13 @@ function _process(id, ast, sourceRoot) {
  * @param {string} opts.map  correspondent source map
  * @param {string} opts.dest The folder to store js and map
  */
-function* _compileFile(id, opts) {
-  var dest = opts.dest
-  var assetPath = path.join(dest, id + '.js')
+function* _compileFile(id, { dest, js, map }) {
+  const assetPath = path.join(dest, id + '.js')
 
   yield mkdirp(path.dirname(assetPath))
   yield [
-    writeFile(assetPath, opts.js + '\n//# sourceMappingURL=./' + path.basename(id) + '.js.map'),
-    writeFile(assetPath + '.map', opts.map)
+    writeFile(assetPath, js + '\n//# sourceMappingURL=./' + path.basename(id) + '.js.map'),
+    writeFile(assetPath + '.map', map)
   ]
 
   debug('compiled %s', id)
@@ -356,21 +355,21 @@ function* compileAll(opts = {}) {
 
       if (minimatch(id + '.js', match)) {
         yield* compileComponent(id, {
-          root: root,
+          root,
           base: bases,
-          dest: dest,
-          dependenciesMap: dependenciesMap,
+          dest,
+          dependenciesMap,
           includeModules: false,
-          sourceRoot: sourceRoot,
-          importConfig: opts.importConfig
+          sourceRoot,
+          loaderConfig: opts.loaderConfig
         })
       }
       else {
         yield* compileComponentPlain(id, {
-          root: root,
+          root,
           base: bases,
-          dest: dest,
-          sourceRoot: sourceRoot
+          dest,
+          sourceRoot
         })
       }
     }
@@ -379,13 +378,13 @@ function* compileAll(opts = {}) {
 
 
 /**
- * @yield {Object} Parsed ast of import.js
+ * @yield {Object} Parsed ast of loader.js
  */
 function* parseLoader() {
-  var loader = yield readFile(path.join(__dirname, '../import.js'), 'utf8')
+  const loader = yield readFile(path.join(__dirname, '../loader.js'), 'utf8')
 
   return UglifyJS.parse(loader, {
-    filename: 'import.js'
+    filename: 'loader.js'
   })
 }
 
@@ -407,29 +406,25 @@ function* compileComponentPlain(id, opts) {
     base: 'components'
   }, opts)
 
-  var root = opts.root
-  var bases = [].concat(opts.base).map(function(base) {
+  const root = opts.root
+  const bases = [].concat(opts.base).map(function(base) {
     return path.resolve(root, base)
   })
 
-  var fpath = yield findComponent(id + '.js', bases)
-  var content = yield readFile(fpath, 'utf8')
+  const fpath = yield findComponent(id + '.js', bases)
+  const content = yield readFile(fpath, 'utf8')
+  const dependencies = matchRequire.findAll(content)
 
-  if (!/^raw\//.test(id)) {
-    let dependencies = matchRequire.findAll(content)
-    content = define(id, dependencies, content)
-  }
-
-  var toplevel = UglifyJS.parse(content, {
+  const toplevel = UglifyJS.parse(define(id, dependencies, content), {
     filename: path.relative(root, fpath)
   })
 
-  var result = _process(id, toplevel, opts.sourceRoot)
-  var dest = opts.dest && path.resolve(root, opts.dest)
+  const result = _process(id, toplevel, opts.sourceRoot)
+  const dest = opts.dest && path.resolve(root, opts.dest)
 
   if (opts.dest) {
     yield* _compileFile(id, {
-      dest: dest,
+      dest,
       js: result.js,
       map: result.map
     })
@@ -498,7 +493,7 @@ function* compileComponent(id, opts) {
   // If not all modules are included, use the full dependencies map instead of
   // the required map generated white bundling.
   var map = includeModules ? requiredMap : dependenciesMap
-  var importConfig = Object.assign(opts.importConfig || {}, parseSystem(map))
+  var loaderConfig = Object.assign(opts.loaderConfig || {}, parseSystem(map))
   var entries = [id.replace(/\.js$/, '')]
 
   if (yield* findComponent('preload.js', bases)) {
@@ -506,7 +501,7 @@ function* compileComponent(id, opts) {
   }
 
   toplevel = UglifyJS.parse([
-    'oceanify.config(' + JSON.stringify(importConfig) + ')',
+    'oceanify.config(' + JSON.stringify(loaderConfig) + ')',
     'oceanify.import(' + JSON.stringify(entries) + ')'
   ].join('\n'), {
     toplevel: toplevel
@@ -517,7 +512,7 @@ function* compileComponent(id, opts) {
 
   if (dest) {
     yield* _compileFile(id, {
-      dest: dest,
+      dest,
       js: result.js,
       map: result.map
     })
@@ -539,21 +534,21 @@ function* compileComponent(id, opts) {
  * @yield {ProcessResult}
  */
 function* compileModule(id, opts) {
-  var root = opts.root || process.cwd()
-  var base = path.resolve(root, opts.base || 'node_modules')
+  const root = opts.root || process.cwd()
+  const base = path.resolve(root, opts.base || 'node_modules')
 
-  var toplevel = yield* _bundle(id, {
+  const toplevel = yield* _bundle(id, {
     root: root,
     bases: base,
     dependenciesMap: opts.dependenciesMap
   })
 
-  var dest = opts.dest && path.resolve(root, opts.dest)
-  var result = _process(id, toplevel, opts.sourceRoot)
+  const dest = opts.dest && path.resolve(root, opts.dest)
+  const result = _process(id, toplevel, opts.sourceRoot)
 
   if (dest) {
     yield* _compileFile(id, {
-      dest: dest,
+      dest,
       js: result.js,
       map: result.map
     })

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -104,7 +104,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  *
  *     _bundle('main', {
  *       root: root,
- *       bases: path.join(root, 'components'),
+ *       paths: path.join(root, 'components'),
  *       dependenciesMap: dependenciesMap,
  *       toplevel: yield* parseLoader(dependenciesMap)
  *     })
@@ -113,7 +113,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  *     // `./lib/foo` can be appended directly but `ez-editor` needs _bundle
  *     _bundle('ez-editor/0.2.4/index', {
  *       root: root,
- *       bases: path.join(root, 'node_modules'),
+ *       paths: path.join(root, 'node_modules'),
  *       dependenciesMap: dependenciesMap,
  *       toplevel: toplevel,   // current toplevel ast,
  *       ids: ['main', 'lib/foo'],
@@ -123,7 +123,7 @@ function findModule(route, dependenciesMap, requiredMap) {
  *     // found out that the dependencies of ez-editor are ['yen'] and so on.
  *     _bundle('yen/1.2.4/index', {
  *       root: path.join(root, 'node_modules/ez-editor'),
- *       bases: path.join(root, 'node_modules/ez-editor/node_modules'),
+ *       paths: path.join(root, 'node_modules/ez-editor/node_modules'),
  *       dependenciesMap: dependenciesMap,
  *       toplevel: toplevel,
  *       ids: ['main', 'lib/foo', 'ez-editor/0.2.4/index'],
@@ -132,36 +132,33 @@ function findModule(route, dependenciesMap, requiredMap) {
  *
  * @param {string}   main
  * @param {Object}   opts
- * @param {string}   opts.root                  the source root
- * @param {string}   opts.bases                 the bases of current module
+ * @param {string}   opts.paths                 The components load paths
+ * @param {string}   opts.root                  The source root
  * @param {object}  [opts.dependenciesMap=null] If passed, will bundle dependencies too
+ * @param {array}   [opts.ids=[]]               The ids of the modules that are bundled already
  * @param {object}  [opts.requiredMap=null]     If passed, the actual dependencies map will be stored here
- * @param {object}  [opts.toplevel=null]        the toplevel ast that contains all the parsed code
- * @param {array}   [opts.ids=[]]               the ids of the modules that are bundled already
- * @param {array}   [opts.route=[]]             the dependency route if called recursively
+ * @param {array}   [opts.route=[]]             The dependency route if called recursively
+ * @param {object}  [opts.toplevel=null]        The toplevel ast that contains all the parsed code
  *
  * @yield {Object} An ast that contains main, relative modules, And
  *   if passed opts.dependenciesMap, all the dependencies.
  */
 function* _bundle(main, opts) {
-  var root = opts.root
-  var bases = [].concat(opts.bases)
-  var toplevel = opts.toplevel
-  var dependenciesMap = opts.dependenciesMap
-  var requiredMap = opts.requiredMap
-
-  var ids = opts.ids || []
-  var route = opts.route || []
+  const paths = [].concat(opts.paths)
+  const { root, dependenciesMap, requiredMap } = opts
+  const ids = opts.ids || []
+  const route = opts.route || []
+  let toplevel = opts.toplevel
 
   function* append(id, dependencies, factory) {
     if (ids.indexOf(id) >= 0) return
     ids.unshift(id)
 
     var sourceId = stripVersion(id)
-    var fpath = yield findComponent(sourceId + '.js', bases)
+    var fpath = yield findComponent(sourceId + '.js', paths)
 
     if (!fpath && !factory) {
-      throw new Error(util.format('Cannot find source of %s in %s', id, bases))
+      throw new Error(util.format('Cannot find source of %s in %s', id, paths))
     }
 
     factory = factory || (yield readFile(fpath, 'utf8'))
@@ -173,7 +170,7 @@ function* _bundle(main, opts) {
       }
     }
 
-    fpath = fpath || path.join(bases[0], sourceId + '.js')
+    fpath = fpath || path.join(paths[0], sourceId + '.js')
     toplevel = UglifyJS.parse(define(id, dependencies, factory), {
       filename: path.relative(root, fpath),
       toplevel: toplevel
@@ -189,7 +186,7 @@ function* _bundle(main, opts) {
       if (dep.charAt(0) === '.') {
         yield* append(path.join(path.dirname(component.id), dep))
       }
-      else if (yield findComponent(dep + '.js', bases)) {
+      else if (yield findComponent(dep + '.js', paths)) {
         yield* append(dep)
       }
       else if (dependenciesMap) {
@@ -209,7 +206,7 @@ function* _bundle(main, opts) {
 
     yield* _bundle(id, {
       root: root,
-      bases: pkgBase,
+      paths: pkgBase,
       dependenciesMap: dependenciesMap,
       requiredMap: requiredMap,
       route: route,
@@ -293,16 +290,16 @@ function* _compileFile(id, { dest, js, map }) {
 
 
 /*
- * Compile all modules under base into target folder.
+ * Compile all components and modules within the root directory into dest folder.
  *
  * Example:
  *
- *   compileAll({ base: './components', match: 'main/*' })
+ *   compileAll({ paths: './components', match: 'main/*' })
  *
  * @param {Object}           opts
- * @param {string|string[]} [opts.base=components]          The base directory to find the sources
  * @param {string}          [opts.dest=public]              The destintation directory
  * @param {string}          [opts.match={**\/main.js}]      The match pattern to find the components to compile
+ * @param {string|string[]} [opts.paths=components]         The base directory to find the sources
  * @param {string}          [opts.root=process.cwd()]       Current working directory
  * @param {string}          [opts.sourceRoot]               The source root
  */
@@ -311,11 +308,11 @@ function* compileAll(opts = {}) {
   const dest = path.resolve(root, opts.dest || 'public')
   const match = opts.match || '**/main.js'
   const sourceRoot = opts.sourceRoot
-  const bases = [].concat(opts.base || 'components').map(function(base) {
-    return path.resolve(root, base)
+  const paths = [].concat(opts.paths || 'components').map(function(dir) {
+    return path.resolve(root, dir)
   })
 
-  const dependenciesMap = yield* parseMap({ root: root, base: bases, dest: dest })
+  const dependenciesMap = yield* parseMap({ root, paths, dest })
   const doneModules = {}
 
   function* walk(deps) {
@@ -330,9 +327,9 @@ function* compileAll(opts = {}) {
       if (doneModule[mod.version]) continue
 
       yield* compileModule(path.join(name, mod.version, main), {
-        root: root,
-        base: pkgBase,
         dest: dest,
+        paths: pkgBase,
+        root: root,
         sourceRoot: sourceRoot
       })
 
@@ -342,21 +339,21 @@ function* compileAll(opts = {}) {
 
   yield* walk(dependenciesMap)
 
-  for (let i = 0; i < bases.length; i++) {
-    const base = bases[i]
-    const entries = yield glob(path.join(base, '**/*.js'))
+  for (let i = 0; i < paths.length; i++) {
+    const currentPath = paths[i]
+    const entries = yield glob(path.join(currentPath, '**/*.js'))
 
     if (!entries.length) {
-      console.error('Found no entries to compile in %s', base)
+      console.error('Found no entries to compile in %s', currentPath)
     }
 
     for (let j = 0, len = entries.length; j < len; j++) {
-      const id = path.relative(base, entries[j]).replace(/\.js$/, '')
+      const id = path.relative(currentPath, entries[j]).replace(/\.js$/, '')
 
       if (minimatch(id + '.js', match)) {
         yield* compileComponent(id, {
           root,
-          base: bases,
+          paths,
           dest,
           dependenciesMap,
           includeModules: false,
@@ -367,7 +364,7 @@ function* compileAll(opts = {}) {
       else {
         yield* compileComponentPlain(id, {
           root,
-          base: bases,
+          paths,
           dest,
           sourceRoot
         })
@@ -395,7 +392,7 @@ function* parseLoader() {
  * @param {string}           id             Component id
  * @param {Object}          [opts]
  * @param {string}          [opts.root]     root directory
- * @param {string|string[]} [opts.base]     base directory
+ * @param {string|string[]} [opts.paths]    components load paths
  * @param {string}          [opts.dest]
  *
  * @yield {ProcessResult}
@@ -403,15 +400,15 @@ function* parseLoader() {
 function* compileComponentPlain(id, opts) {
   opts = Object.assign({
     root: process.cwd(),
-    base: 'components'
+    paths: 'components'
   }, opts)
 
   const root = opts.root
-  const bases = [].concat(opts.base).map(function(base) {
-    return path.resolve(root, base)
+  const paths = [].concat(opts.paths).map(function(dir) {
+    return path.resolve(root, dir)
   })
 
-  const fpath = yield findComponent(id + '.js', bases)
+  const fpath = yield findComponent(id + '.js', paths)
   const content = yield readFile(fpath, 'utf8')
   const dependencies = matchRequire.findAll(content)
 
@@ -438,11 +435,11 @@ function* compileComponentPlain(id, opts) {
  * @param {string}           id
  * @param {Object}           opts
  * @param {DependenciesMap}  opts.dependenciesMap       Notice the bundling behavior is controlled by opts.includeModules
- * @param {string}          [opts.dest]
- * @param {string|string[]} [opts.base=components]
- * @param {boolean}         [opts.includeModules]       Whethor to include node_modules or not
  * @param {Array}           [opts.dependencies]         Dependencies of the entry module
+ * @param {string}          [opts.dest]
  * @param {string}          [opts.factory]              Factory code of the entry module
+ * @param {boolean}         [opts.includeModules]       Whethor to include node_modules or not
+ * @param {string|string[]} [opts.paths=components]
  * @param {string}          [opts.root=process.cwd()]
  * @param {string}          [opts.sourceRoot]
  *
@@ -451,34 +448,32 @@ function* compileComponentPlain(id, opts) {
 function* compileComponent(id, opts) {
   opts = Object.assign({
     root: process.cwd(),
-    base: 'components',
+    paths: 'components',
     includeModules: true
   }, opts)
 
-  var root = opts.root
-  var bases = [].concat(opts.base).map(function(base) {
-    return path.resolve(root, base)
+  const { root, dependenciesMap, includeModules } = opts
+  const paths = [].concat(opts.paths).map(function(dir) {
+    return path.resolve(root, dir)
   })
-  var dependenciesMap = opts.dependenciesMap
-  var includeModules = opts.includeModules
 
   if (!dependenciesMap) {
     return yield* compileComponentPlain(id, opts)
   }
 
-  var factory = opts.factory
-
+  let factory = opts.factory
+  
   if (!factory) {
-    let fpath = yield findComponent(id + '.js', bases)
+    const fpath = yield findComponent(id + '.js', paths)
     factory = yield readFile(fpath, 'utf8')
   }
 
-  var dependencies = opts.dependencies || matchRequire.findAll(factory)
-  var requiredMap = {}
-  var toplevel = yield* parseLoader()
-  var bundleOpts = {
+  const dependencies = opts.dependencies || matchRequire.findAll(factory)
+  const requiredMap = {}
+  let toplevel = yield* parseLoader()
+  const bundleOpts = {
     root,
-    bases,
+    paths,
     dependencies,
     factory,
     toplevel
@@ -492,23 +487,18 @@ function* compileComponent(id, opts) {
 
   // If not all modules are included, use the full dependencies map instead of
   // the required map generated white bundling.
-  var map = includeModules ? requiredMap : dependenciesMap
-  var loaderConfig = Object.assign(opts.loaderConfig || {}, parseSystem(map))
-  var entries = [id.replace(/\.js$/, '')]
+  const map = includeModules ? requiredMap : dependenciesMap
+  const loaderConfig = Object.assign(opts.loaderConfig || {}, parseSystem(map))
 
-  if (yield* findComponent('preload.js', bases)) {
-    entries.unshift('preload')
-  }
-
-  toplevel = UglifyJS.parse([
-    'oceanify.config(' + JSON.stringify(loaderConfig) + ')',
-    'oceanify.import(' + JSON.stringify(entries) + ')'
-  ].join('\n'), {
+  toplevel = UglifyJS.parse(`
+oceanify.config(${JSON.stringify(loaderConfig)})
+oceanify.import(${JSON.stringify(id.replace(/\.js$/, ''))})
+`, {
     toplevel: toplevel
   })
 
-  var dest = opts.dest && path.resolve(root, opts.dest)
-  var result = _process(id, toplevel, opts.sourceRoot)
+  const dest = opts.dest && path.resolve(root, opts.dest)
+  const result = _process(id, toplevel, opts.sourceRoot)
 
   if (dest) {
     yield* _compileFile(id, {
@@ -525,21 +515,25 @@ function* compileComponent(id, opts) {
 /**
  * @param {string}  id
  * @param {Object}  opts
- * @param {string} [opts.dest]                  If passed, will write .js and .map files
- * @param {string} [opts.base=node_modules]
  * @param {Object} [opts.dependenciesMap=null]  If passed, will include all the dependencies
+ * @param {string} [opts.dest]                  If passed, will write .js and .map files
+ * @param {string} [opts.paths=node_modules]    Actually only the first load path will be used
  * @param {string} [opts.root=process.cwd()]
  * @param {string} [opts.sourceRoot]
  *
  * @yield {ProcessResult}
  */
 function* compileModule(id, opts) {
-  const root = opts.root || process.cwd()
-  const base = path.resolve(root, opts.base || 'node_modules')
+  opts = Object.assign({ 
+    root: process.cwd(),
+    paths: 'node_modules'
+  }, opts)
+  const { root, paths } = opts
+  const currentPath = path.resolve(root, Array.isArray(paths) ? paths[0] : paths) 
 
   const toplevel = yield* _bundle(id, {
     root: root,
-    bases: base,
+    paths: currentPath,
     dependenciesMap: opts.dependenciesMap
   })
 

--- a/lib/compileAll.js
+++ b/lib/compileAll.js
@@ -9,7 +9,6 @@ const util = require('util')
 const debug = require('debug')('oceanify')
 const UglifyJS = require('uglify-js')
 const semver = require('semver')
-const objectAssign = require('object-assign')
 const minimatch = require('minimatch')
 const matchRequire = require('match-require')
 
@@ -404,7 +403,7 @@ function* parseLoader() {
  * @yield {ProcessResult}
  */
 function* compileComponentPlain(id, opts) {
-  opts = objectAssign({
+  opts = Object.assign({
     root: process.cwd(),
     base: 'components'
   }, opts)
@@ -456,7 +455,7 @@ function* compileComponentPlain(id, opts) {
  * @yield {ProcessResult}
  */
 function* compileComponent(id, opts) {
-  opts = objectAssign({
+  opts = Object.assign({
     root: process.cwd(),
     base: 'components',
     includeModules: true
@@ -492,7 +491,7 @@ function* compileComponent(id, opts) {
   }
 
   if (includeModules) {
-    objectAssign(bundleOpts, {
+    Object.assign(bundleOpts, {
       dependenciesMap: dependenciesMap,
       requiredMap: requiredMap
     })
@@ -503,7 +502,7 @@ function* compileComponent(id, opts) {
   // If not all modules are included, use the full dependencies map instead of
   // the required map generated white bundling.
   var map = includeModules ? requiredMap : dependenciesMap
-  var importConfig = objectAssign(opts.importConfig || {}, parseSystem(map))
+  var importConfig = Object.assign(opts.importConfig || {}, parseSystem(map))
   var entries = [id.replace(/\.js$/, '')]
 
   if (yield* findComponent('preload.js', bases)) {

--- a/lib/compileStyleSheets.js
+++ b/lib/compileStyleSheets.js
@@ -37,6 +37,12 @@ function* compileStyleSheets(opts) {
 }
 
 
+const processor = postcss()
+  .use(autoprefixer())
+  .use(atImport({
+    path: [ path.join(process.cwd(), 'node_modules') ]
+  }))
+
 /**
  * Compile styles in components
  *
@@ -54,12 +60,7 @@ function* compileStyleSheet(opts) {
   var destPath = path.join(dest, path.relative(base, fpath))
   var source = yield readFile(fpath)
 
-  var result = postcss()
-    .use(autoprefixer())
-    .use(atImport({
-      path: [ path.join(cwd, 'node_modules') ]
-    }))
-    .process(source, {
+  var result = yield processor.process(source, {
       from: path.relative(cwd, fpath),
       to: path.relative(base, fpath),
       map: { inline: false }

--- a/lib/compileStyleSheets.js
+++ b/lib/compileStyleSheets.js
@@ -35,10 +35,10 @@ function* compileStyleSheets(opts) {
   const match = opts.match || '{main,main/**/*}.css'
 
   const processor = postcss()
-    .use(autoprefixer())
     .use(atImport({
       path: [ path.join(process.cwd(), 'node_modules') ].concat(paths)
     }))
+    .use(autoprefixer())
 
   for (let i = 0; i < paths.length; i++) {
     const currentPath = paths[i]

--- a/lib/compileStyleSheets.js
+++ b/lib/compileStyleSheets.js
@@ -19,18 +19,18 @@ const writeFile = fs.writeFile
 
 /**
  * Compile stylesheets in components
- * 
+ *
  * @param {Object}    opts
  * @param {string}    opts.dest
  * @param {string}    opts.match
- * @param {string[]}  opts.paths 
+ * @param {string[]}  opts.paths
  */
 function* compileStyleSheets(opts) {
   opts = opts || {}
   const cwd = process.cwd()
   const paths = [].concat(opts.paths || 'components').map(function(dir) {
     return path.resolve(cwd, dir)
-  }) 
+  })
   const dest = path.resolve(cwd, opts.dest || 'public')
   const match = opts.match || '{main,main/**/*}.css'
 
@@ -39,16 +39,16 @@ function* compileStyleSheets(opts) {
     .use(atImport({
       path: [ path.join(process.cwd(), 'node_modules') ].concat(paths)
     }))
-  
+
   for (let i = 0; i < paths.length; i++) {
     const currentPath = paths[i]
     const entries = yield glob(path.join(currentPath, match))
-    
+
     for (let j = 0; j < entries.length; j++) {
       yield* compileStyleSheet(processor, {
-        cwd, 
+        cwd,
         dest,
-        id: path.relative(currentPath, entries[i]),
+        id: path.relative(currentPath, entries[j]),
         path: currentPath
       })
     }

--- a/lib/compileStyleSheets.js
+++ b/lib/compileStyleSheets.js
@@ -17,52 +17,65 @@ const readFile = fs.readFile
 const writeFile = fs.writeFile
 
 
+/**
+ * Compile stylesheets in components
+ * 
+ * @param {Object}    opts
+ * @param {string}    opts.dest
+ * @param {string}    opts.match
+ * @param {string[]}  opts.paths 
+ */
 function* compileStyleSheets(opts) {
   opts = opts || {}
-  var cwd = process.cwd()
-  var base = path.resolve(cwd, opts.base || 'components')
-  var dest = path.resolve(cwd, opts.dest || 'public')
-  var match = opts.match || '{main,main/**/*}.css'
+  const cwd = process.cwd()
+  const paths = [].concat(opts.paths || 'components').map(function(dir) {
+    return path.resolve(cwd, dir)
+  }) 
+  const dest = path.resolve(cwd, opts.dest || 'public')
+  const match = opts.match || '{main,main/**/*}.css'
 
-  var entries = yield glob(path.join(base, match))
-
-  for (var i = 0, len = entries.length; i < len; i++) {
-    yield* compileStyleSheet({
-      cwd: cwd,
-      base: base,
-      dest: dest,
-      fpath: entries[i],
-    })
+  const processor = postcss()
+    .use(autoprefixer())
+    .use(atImport({
+      path: [ path.join(process.cwd(), 'node_modules') ].concat(paths)
+    }))
+  
+  for (let i = 0; i < paths.length; i++) {
+    const currentPath = paths[i]
+    const entries = yield glob(path.join(currentPath, match))
+    
+    for (let j = 0; j < entries.length; j++) {
+      yield* compileStyleSheet(processor, {
+        cwd, 
+        dest,
+        id: path.relative(currentPath, entries[i]),
+        path: currentPath
+      })
+    }
   }
 }
 
 
-const processor = postcss()
-  .use(autoprefixer())
-  .use(atImport({
-    path: [ path.join(process.cwd(), 'node_modules') ]
-  }))
-
 /**
- * Compile styles in components
+ * Compile stylesheet in components
  *
+ * @param {Object} processor
  * @param {Object} opts
- * @param {string} opts.root
- * @param {string} opts.base
+ * @param {string} opts.cwd
  * @param {string} opts.dest
+ * @param {string} opts.id
+ * @param {string} opts.path
  */
-function* compileStyleSheet(opts) {
-  var cwd = process.cwd()
-  var base = opts.base
-  var dest = opts.dest
-  var fpath = opts.fpath
+function* compileStyleSheet(processor, opts) {
+  const { cwd, path: currentPath, dest, id } = opts
 
-  var destPath = path.join(dest, path.relative(base, fpath))
-  var source = yield readFile(fpath)
+  const destPath = path.join(dest, id)
+  const fpath = path.join(currentPath, id)
+  const source = yield readFile(fpath, 'utf8')
 
-  var result = yield processor.process(source, {
+  const result = yield processor.process(source, {
       from: path.relative(cwd, fpath),
-      to: path.relative(base, fpath),
+      to: id,
       map: { inline: false }
     })
 

--- a/lib/findComponent.js
+++ b/lib/findComponent.js
@@ -14,12 +14,12 @@ const exists = require('./fs').exists
  * Find the path of a component in mutiple base directories
  *
  * @param {string} id
- * @param {Array}  bases
+ * @param {Array}  paths
  * @yield {string} path of the component found
  */
-function* findComponent(id, bases) {
-  for (let i = 0; i < bases.length; i++) {
-    let componentPath = path.join(bases[i], id)
+function* findComponent(id, paths) {
+  for (let i = 0; i < paths.length; i++) {
+    let componentPath = path.join(paths[i], id)
     if (yield exists(componentPath)) {
       return componentPath
     }

--- a/lib/glob.js
+++ b/lib/glob.js
@@ -3,9 +3,9 @@
 const glob = require('glob')
 
 
-module.exports = function globAsync(pattern) {
+module.exports = function globAsync(pattern, opts = {}) {
   return new Promise(function(resolve, reject) {
-    glob(pattern, function(err, entries) {
+    glob(pattern, opts, function(err, entries) {
       if (err) reject(new Error(err))
       else resolve(entries)
     })

--- a/lib/parseMap.js
+++ b/lib/parseMap.js
@@ -199,7 +199,7 @@ function* parseMap(opts) {
      * shall be ignored because a component shall never reside in that.
      * paths like foo/node_modules cannot be ruled out by current approach.
      */
-    const pattern = path.join(currentPath, '!(node_modules)/**/*.js')
+    const pattern = path.join(currentPath, '{*.js,!(node_modules)/**/*.js}')
     const entries = yield glob(pattern, { cwd: currentPath })
     const components = yield entries.map(parseComponent)
 

--- a/lib/parseMap.js
+++ b/lib/parseMap.js
@@ -159,15 +159,15 @@ function* parseMap(opts) {
   var root = opts.root || process.cwd()
   var encoding = opts.encoding || 'utf8'
   var pkg = require(path.relative(__dirname, path.join(root, 'package.json')))
-  var bases = [].concat(opts.base || 'components').map(function(dir) {
+  var paths = [].concat(opts.paths || 'components').map(function(dir) {
     return path.resolve(root, dir)
   })
-  var base
+  var currentPath
   var dependencies = {}
 
   function* parseComponent(fpath) {
     var code = yield readFile(fpath, encoding)
-    var id = path.relative(base, fpath).replace(/\.js$/, '')
+    var id = path.relative(currentPath, fpath).replace(/\.js$/, '')
 
     return {
       id: id,
@@ -183,7 +183,7 @@ function* parseMap(opts) {
       if (name.charAt(0) === '.' || name in result) continue
 
       // exists in components dir.
-      if (yield* findComponent(name + '.js', bases)) continue
+      if (yield* findComponent(name + '.js', paths)) continue
 
       // local module
       if (name === pkg.name) continue
@@ -202,12 +202,12 @@ function* parseMap(opts) {
     return result
   }
 
-  for (var i = 0; i < bases.length; i++) {
-    base = bases[i]
-    var components = yield glob(path.join(base, '**/*.js'))
+  for (var i = 0; i < paths.length; i++) {
+    currentPath = paths[i]
+    var components = yield glob(path.join(currentPath, '**/*.js'))
     components = yield components.map(parseComponent)
 
-    if (opts.self) {
+    if (opts.serveSelf) {
       dependencies[pkg.name] = yield* resolveModule({
         name: pkg.name,
         pkgRoot: root

--- a/lib/parseMap.js
+++ b/lib/parseMap.js
@@ -4,25 +4,15 @@
  * @module
  */
 
-const _glob = require('glob')
 const path = require('path')
 const format = require('util').format
 const matchRequire = require('match-require')
 
 const fs = require('./fs')
+const glob = require('./glob')
 
 const readFile = fs.readFile
 const exists = fs.exists
-
-
-function glob(dir) {
-  return new Promise(function(resolve, reject) {
-    _glob(dir, function(err, entries) {
-      if (err) reject(err)
-      else resolve(entries)
-    })
-  })
-}
 
 
 function* closest(root, name) {
@@ -204,8 +194,14 @@ function* parseMap(opts) {
 
   for (var i = 0; i < paths.length; i++) {
     currentPath = paths[i]
-    var components = yield glob(path.join(currentPath, '**/*.js'))
-    components = yield components.map(parseComponent)
+    /**
+     * glob all components within current path. js files within node_modules
+     * shall be ignored because a component shall never reside in that.
+     * paths like foo/node_modules cannot be ruled out by current approach.
+     */
+    const pattern = path.join(currentPath, '!(node_modules)/**/*.js')
+    const entries = yield glob(pattern, { cwd: currentPath })
+    const components = yield entries.map(parseComponent)
 
     if (opts.serveSelf) {
       dependencies[pkg.name] = yield* resolveModule({

--- a/loader.js
+++ b/loader.js
@@ -150,7 +150,7 @@
 
     if (map) {
       for (var pattern in map) {
-        ret = uri.replace(new RegExp(pattern), map[pattern])
+        ret = uri.replace(new RegExp('^' + pattern), map[pattern])
         // Only apply the first matched rule
         if (ret !== uri) break
       }
@@ -219,7 +219,9 @@
       var id = parseMap(mod.id)
       var uri = /^https?:\/\//.test(id) || id.charAt(0) === '/'
         ? id
-        : resolve(system.base, mod.id + '.js')
+        : resolve(system.base, mod.id)
+        
+      uri = uri.replace(/\.js$/, '') + '.js'
 
       request(uri, function(err) {
         mod.status = err ? MODULE_ERROR : MODULE_FETCHED

--- a/loader.js
+++ b/loader.js
@@ -5,9 +5,9 @@
   // do not override
   if (global.oceanify) return
 
-  var system = { 
+  var system = {
     preload: [],
-    registry: {} 
+    registry: {}
   }
   var registry = system.registry
 
@@ -23,11 +23,15 @@
         var source = args.shift()
 
         for (var p in source) {
-          if (source.hasOwnProperty(p)) {
-            target[p] = source[p]
+          if (source != null) {
+            if (source.hasOwnProperty(p)) {
+              target[p] = source[p]
+            }
           }
         }
       }
+
+      return target
     }
   }
 
@@ -223,7 +227,7 @@
       var uri = /^https?:\/\//.test(id) || id.charAt(0) === '/'
         ? id
         : resolve(system.base, mod.id)
-        
+
       uri = uri.replace(/\.js$/, '') + '.js'
 
       request(uri, function(err) {

--- a/loader.js
+++ b/loader.js
@@ -5,7 +5,10 @@
   // do not override
   if (global.oceanify) return
 
-  var system = { registry: {} }
+  var system = { 
+    preload: [],
+    registry: {} 
+  }
   var registry = system.registry
 
 
@@ -357,8 +360,12 @@
   }
 
 
+  var globalImport = importFactory()
+
   Object.assign(system, {
-    'import': importFactory(),
+    'import': function(ids, fn) {
+      globalImport([].concat(system.preload, ids), fn)
+    },
 
     config: function(opts) {
       return Object.assign(system, opts)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.6",
+  "version": "5.0.0-beta.7",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"
@@ -10,7 +10,7 @@
     "autoprefixer": "~6.3.0",
     "co": "~4.6.0",
     "debug": "~1.0.4",
-    "glob": "~3.2.9",
+    "glob": "^7.0.5",
     "heredoc": "~1.3.1",
     "match-require": "~1.1.1",
     "mime": "~1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A connect middleware for browser side javascript module authoring.",
-  "version": "4.3.2",
+  "version": "5.0.0-beta.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"
@@ -34,6 +34,6 @@
     "cover": "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test/{,command}/test.*.js -- --timeout 15000"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.8",
+  "version": "5.0.0-beta.9",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.7",
+  "version": "5.0.0-beta.8",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A connect middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.5",
+  "version": "5.0.0-beta.6",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:erzu/oceanify.git"
   },
   "dependencies": {
-    "autoprefixer": "~6.0.0",
+    "autoprefixer": "~6.3.0",
     "co": "~4.6.0",
     "debug": "~1.0.4",
     "glob": "~3.2.9",
@@ -17,9 +17,8 @@
     "minimatch": "~3.0.0",
     "minimist": "~1.2.0",
     "mkdirp": "~0.3.5",
-    "object-assign": "~4.0.1",
     "postcss": "~5.0.4",
-    "postcss-import": "~7.0.0",
+    "postcss-import": "~8.0.2",
     "semver": "~4.0.0",
     "uglify-js": "~2.4.23"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
-  "description": "A connect middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.1",
+  "description": "A koa and express middleware for browser side javascript module authoring.",
+  "version": "5.0.0-beta.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"

--- a/test/command/test.compileModule.js
+++ b/test/command/test.compileModule.js
@@ -33,9 +33,9 @@ describe('bin/compileModule.js', function() {
   it('compiles module', function* () {
     yield spawn(process.argv[0], [
       '--harmony',
-      path.join(root, '../../bin/compileModule.js'),
+      path.resolve(root, '../../bin/compileModule.js'),
       '--id', 'yen/1.2.4/index',
-      '--base', path.join(root, 'node_modules'),
+      '--paths', path.join(root, 'node_modules'),
       '--dest', path.join(root, 'public')
     ])
 

--- a/test/example-fe/app.js
+++ b/test/example-fe/app.js
@@ -13,8 +13,8 @@ app.use(serve('public'))
 app.use(oceanify({
   root: __dirname,
   dest: path.join(__dirname, 'public'),
-  base: path.join(__dirname, 'test'),
-  self: true
+  paths: path.join(__dirname, 'test'),
+  serveSelf: true
 }))
 
 

--- a/test/example/app.js
+++ b/test/example/app.js
@@ -14,9 +14,9 @@ app.use(oceanify({
   root: __dirname,
   dest: path.join(__dirname, 'public'),
   serveSource: true,
-  importConfig: {
+  loaderConfig: {
     map: {
-      'templates/(\\d+)': '/templates/$1.js'
+      'templates': '/templates'
     }
   }
 }))

--- a/test/test.compileAll.js
+++ b/test/test.compileAll.js
@@ -19,7 +19,7 @@ describe('oceanify.compileAll', function() {
   it('should compile all components and their dependencies', function* () {
     yield compileAll({
       root: root,
-      base: 'components',
+      paths: 'components',
       dest: 'public',
       sourceOptions: { root: '/' }
     })
@@ -38,10 +38,10 @@ describe('oceanify.compileAll', function() {
     expect(entries).to.contain('public/crox/1.3.1/build/crox-all.js.map')
   })
 
-  it('should compile components in muitiple bases', function* () {
+  it('should compile components in muitiple paths', function* () {
     yield compileAll({
       root: root,
-      base: ['components', 'browser_modules'],
+      paths: ['components', 'browser_modules'],
       dest: 'public',
       sourceOptions: { root: '/' }
     })

--- a/test/test.compileAll.js
+++ b/test/test.compileAll.js
@@ -18,9 +18,10 @@ describe('oceanify.compileAll', function() {
 
   it('should compile all components and their dependencies', function* () {
     yield compileAll({
-      root: root,
-      paths: 'components',
       dest: 'public',
+      match: 'main.js',
+      paths: 'components',
+      root: root,
       sourceOptions: { root: '/' }
     })
 
@@ -40,9 +41,10 @@ describe('oceanify.compileAll', function() {
 
   it('should compile components in muitiple paths', function* () {
     yield compileAll({
-      root: root,
-      paths: ['components', 'browser_modules'],
       dest: 'public',
+      match: 'v2/main.js',
+      paths: ['components', 'browser_modules'],
+      root: root,
       sourceOptions: { root: '/' }
     })
 

--- a/test/test.index.js
+++ b/test/test.index.js
@@ -48,7 +48,7 @@ describe('oceanify', function() {
   it('should start from main', function* () {
     var res = yield requestPath('/main.js')
     expect(res.text).to.contain('\ndefine("main"')
-    expect(res.text).to.contain('\noceanify["import"](["preload","main"])')
+    expect(res.text).to.contain('\noceanify["import"]("main")')
   })
 
   it('should handle components', function *() {

--- a/test/test.index.js
+++ b/test/test.index.js
@@ -46,7 +46,7 @@ function sleep(seconds) {
 
 describe('oceanify', function() {
   it('should start from main', function* () {
-    var res = yield requestPath('/main.js')
+    var res = yield requestPath('/main.js?main')
     expect(res.text).to.contain('\ndefine("main"')
     expect(res.text).to.contain('\noceanify["import"]("main")')
   })

--- a/test/test.parseMap.js
+++ b/test/test.parseMap.js
@@ -10,9 +10,9 @@ var parseMap = require('../lib/parseMap')
 describe('oceanify.parseMap', function() {
   it('parse frontend module', function* () {
     var map = yield* parseMap({
-      base: 'test',
+      paths: 'test',
       root: path.join(__dirname, 'example-fe'),
-      self: true
+      serveSelf: true
     })
 
     expect(map).to.be.an(Object)

--- a/test/test.serveSelf.js
+++ b/test/test.serveSelf.js
@@ -1,11 +1,11 @@
 'use strict'
 
 require('co-mocha')
-var request = require('supertest')
-var matchRequire = require('match-require')
-var expect = require('expect.js')
+const request = require('supertest')
+const matchRequire = require('match-require')
+const expect = require('expect.js')
 
-var app = require('./example-fe/app')
+const app = require('./example-fe/app')
 
 
 function requestPath(apath) {
@@ -21,7 +21,7 @@ function requestPath(apath) {
 }
 
 
-describe('oceanify self', function() {
+describe('oceanify opts.serveSelf', function() {
   it('should serve self', function* () {
     yield requestPath('/oceanify-example-fe/0.0.1/index.js')
   })

--- a/test/test.serveSource.js
+++ b/test/test.serveSource.js
@@ -21,8 +21,8 @@ function requestPath(apath) {
 
 
 describe('oceanify serveSource', function() {
-  it('should serve import.js', function* () {
-    yield requestPath('/import.js')
+  it('should serve loader.js', function* () {
+    yield requestPath('/loader.js')
   })
 
   it('should serve components source', function* () {


### PR DESCRIPTION
- 去掉 Node.js 4 支持
- 修改 opts.base 为 opts.paths 以体现支持多个 components 目录的特性
- opts.importConfig 改为 opts.loaderConfig
  - 增加 opts.loaderConfig.preload
  - 完善 opts.loaderConfig.map，减少需要写正则的场景
- opts.self 改为 opts.serveSelf
- 支持传入 opts.dependenciesMap 以使用 remote base
- 无论开发时还是编译时都合并 `@import`，以确保 node_modules 中的样式可以顺利引用，以及被 autoprefixer 处理
- 重命名 import.js 为 loader.js，更顾名思义一点