### PR TITLE
Fix: /component/entry should be supported still

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ function oceanify(opts = {}) {
   if (['name', 'version', 'main', 'modules'].every(name => !!loaderConfig[name])) {
     parseSystemPromise = new Promise(function(resolve) {
       pkg = system = loaderConfig
+      resolve()
     })
   } else {
     parseSystemPromise = co(function* () {
@@ -171,6 +172,11 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
     if (!system) yield parseSystemPromise
 
     const mod = parseId(id, system)
+    if (!(mod.name in system.modules)) {
+      mod.name = system.name
+      mod.version = system.version
+      mod.entry = id
+    }
     const fpath = mod.name === pkg.name
       ? yield* findComponent(mod.entry, paths)
       : findModule(mod, dependenciesMap)
@@ -201,6 +207,11 @@ oceanify["import"](${JSON.stringify(id.replace(RE_EXT, ''))})
 
   function* readStyle(id) {
     const mod = parseId(id, system)
+    if (!(mod.name in system.modules)) {
+      mod.name = system.name
+      mod.version = system.version
+      mod.entry = id
+    }
     const destPath = path.join(dest, id)
     const fpath = yield* findComponent(mod.entry, paths)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oceanify",
   "description": "A koa and express middleware for browser side javascript module authoring.",
-  "version": "5.0.0-beta.13",
+  "version": "5.0.0-beta.14",
   "repository": {
     "type": "git",
     "url": "git@github.com:erzu/oceanify.git"


### PR DESCRIPTION
Oceanify@5 introduces a lot of breaking changes. One of them is that the
components, both css and js, are now referenced with full path in the
format of `/${name}/${version}/${entry}`. This change makes versioning
of components possible.

The change itself is not backward compatible, which makes legacy
code hard to upgrade. Hence with this commit, we brought the good old
`/${entry}` reference of component back.

Be warned, the components still will be compiled into
`${dest}/${name}/${version}/` directory. This commit only brings the dev
behaviour back.